### PR TITLE
Add bounded EasyConn startup retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The app should continue to open normally. Only the related feature is unavailabl
 
 ## Current Status
 
-The current Android client is version `0.8.2-beta.6` (`44`) and targets Android 14/API 34 and newer.
+The current Android client is version `0.8.2-beta.7` (`45`) and targets Android 14/API 34 and newer.
 
 This build has been tested end-to-end for mirroring and Android Auto on a OnePlus 13 and a CFMOTO 700MT-ADV T-Box. Compatibility with other phones, motorcycle models, T-Box firmware versions, and Android Auto versions is not guaranteed and must be validated separately.
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "io.motohub.android"
         minSdk = 34
         targetSdk = 36
-        versionCode = 44
-        versionName = "0.8.2-beta.6"
+        versionCode = 45
+        versionName = "0.8.2-beta.7"
     }
 
     signingConfigs {

--- a/apps/android/app/src/main/java/io/motohub/android/tbox/EasyConnRetry.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/tbox/EasyConnRetry.kt
@@ -1,0 +1,84 @@
+package io.motohub.android.tbox
+
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
+internal data class EasyConnRetryPolicy(
+    val maxAttempts: Int = 3,
+    val initialDelayMillis: Long = 750L,
+    val maximumDelayMillis: Long = 2_000L,
+    val backoffMultiplier: Int = 2
+) {
+    init {
+        require(maxAttempts > 0)
+        require(initialDelayMillis >= 0)
+        require(maximumDelayMillis >= initialDelayMillis)
+        require(backoffMultiplier >= 1)
+    }
+}
+
+internal suspend fun <T> retryEasyConnStart(
+    policy: EasyConnRetryPolicy,
+    shouldRetry: (Throwable) -> Boolean,
+    onRetry: (failedAttempt: Int, delayMillis: Long, failure: Throwable) -> Unit = { _, _, _ -> },
+    sleeper: suspend (Long) -> Unit = { delay(it) },
+    operation: suspend (attempt: Int) -> T
+): T {
+    var retryDelayMillis = policy.initialDelayMillis
+    for (attempt in 1..policy.maxAttempts) {
+        try {
+            return operation(attempt)
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (failure: Throwable) {
+            if (attempt == policy.maxAttempts || !shouldRetry(failure)) throw failure
+            onRetry(attempt, retryDelayMillis, failure)
+            sleeper(retryDelayMillis)
+            retryDelayMillis = (retryDelayMillis * policy.backoffMultiplier)
+                .coerceAtMost(policy.maximumDelayMillis)
+        }
+    }
+    error("EasyConn retry loop completed without a result")
+}
+
+internal fun isTransientEasyConnFailure(failure: Throwable): Boolean {
+    if (failure is CancellationException) return false
+
+    val failureChain = generateSequence(failure) { it.cause }.toList()
+    val detail = failureChain
+        .mapNotNull(Throwable::message)
+        .joinToString(" ")
+        .lowercase()
+
+    if (PERMANENT_FAILURE_MARKERS.any(detail::contains)) return false
+    if (failureChain.any { it is IOException }) return true
+    return TRANSIENT_FAILURE_MARKERS.any(detail::contains)
+}
+
+private val PERMANENT_FAILURE_MARKERS = listOf(
+    "already running",
+    "host is not set",
+    "mux source is not set",
+    "invalid ec init socket descriptor",
+    "unable to adopt ec init socket",
+    "unable to release ec init descriptor",
+    "start reverse server"
+)
+
+private val TRANSIENT_FAILURE_MARKERS = listOf(
+    "context deadline exceeded",
+    "i/o timeout",
+    "timed out",
+    "timeout",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "no route to host",
+    "network is unreachable",
+    "failed to decode response",
+    "no response",
+    "initialize easyconn stream",
+    "unsuccessful ec response"
+)

--- a/apps/android/app/src/main/java/io/motohub/android/tbox/RideDaemonTransport.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/tbox/RideDaemonTransport.kt
@@ -20,6 +20,7 @@ import java.net.Socket
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -126,27 +127,54 @@ class RideDaemonTransport(
     }
 
     /** Opens the EasyConn command socket through Android's selected T-Box network. */
-    private fun startWithNetworkSocket(
+    private suspend fun startWithNetworkSocket(
+        activeSession: MobileSession,
+        host: TBoxHost,
+        network: Network
+    ) {
+        val policy = EasyConnRetryPolicy()
+        retryEasyConnStart(
+            policy = policy,
+            shouldRetry = ::isTransientEasyConnFailure,
+            onRetry = { failedAttempt, delayMillis, failure ->
+                ProjectionEventLog.warning(
+                    "TBOX",
+                    "EasyConn attempt $failedAttempt/${policy.maxAttempts} failed: " +
+                        "${failure.message.orEmpty()}. Retrying in ${delayMillis}ms."
+                )
+            }
+        ) { attempt ->
+            kotlinx.coroutines.currentCoroutineContext().ensureActive()
+            ProjectionEventLog.debug(
+                "TBOX",
+                "EasyConn attempt $attempt/${policy.maxAttempts}: opening network-bound command " +
+                    "socket to ${host.ipAddress}:${host.port} on network=$network."
+            )
+            startSingleAttempt(activeSession, host, network)
+            if (attempt > 1) {
+                ProjectionEventLog.record(
+                    "TBOX",
+                    "EasyConn handshake recovered on attempt $attempt/${policy.maxAttempts}."
+                )
+            }
+        }
+    }
+
+    private fun startSingleAttempt(
         activeSession: MobileSession,
         host: TBoxHost,
         network: Network
     ) {
         val socket: Socket = network.socketFactory.createSocket()
-        var descriptorTransferred = false
-        try {
-            ProjectionEventLog.debug(
-                "TBOX",
-                "Opening network-bound command socket to ${host.ipAddress}:${host.port} on network=$network."
-            )
-            socket.connect(InetSocketAddress(host.ipAddress, host.port), EC_CONNECT_TIMEOUT_MS)
+        socket.use {
+            it.connect(InetSocketAddress(host.ipAddress, host.port), EC_CONNECT_TIMEOUT_MS)
             ProjectionEventLog.record("TBOX", "EasyConn TCP command socket connected.")
-            val descriptor = ParcelFileDescriptor.fromSocket(socket)
-            val fd = descriptor.detachFd().toLong()
-            descriptorTransferred = true
-            activeSession.startSessionWithSocketFd(fd)
-        } finally {
-            // After detachFd(), Go owns and closes the descriptor during the init handshake.
-            if (!descriptorTransferred) socket.close()
+            ParcelFileDescriptor.fromSocket(it).use { descriptor ->
+                val fd = descriptor.detachFd().toLong()
+                // ParcelFileDescriptor duplicates the socket descriptor. Go owns and closes the
+                // detached duplicate; the outer use{} closes the original Java socket.
+                activeSession.startSessionWithSocketFd(fd)
+            }
         }
     }
 

--- a/apps/android/app/src/test/java/io/motohub/android/tbox/EasyConnRetryTest.kt
+++ b/apps/android/app/src/test/java/io/motohub/android/tbox/EasyConnRetryTest.kt
@@ -1,0 +1,138 @@
+package io.motohub.android.tbox
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class EasyConnRetryTest {
+    @Test
+    fun `returns immediately when the first attempt succeeds`() = runBlocking {
+        val attempts = mutableListOf<Int>()
+
+        val result = retryEasyConnStart(
+            policy = policy(),
+            shouldRetry = { true },
+            sleeper = { fail("A successful first attempt must not sleep") }
+        ) { attempt ->
+            attempts += attempt
+            "ready"
+        }
+
+        assertEquals("ready", result)
+        assertEquals(listOf(1), attempts)
+    }
+
+    @Test
+    fun `retries transient failures with bounded exponential delays`() = runBlocking {
+        val attempts = mutableListOf<Int>()
+        val delays = mutableListOf<Long>()
+        val retryAttempts = mutableListOf<Int>()
+
+        val result = retryEasyConnStart(
+            policy = policy(),
+            shouldRetry = ::isTransientEasyConnFailure,
+            onRetry = { failedAttempt, _, _ -> retryAttempts += failedAttempt },
+            sleeper = delays::add
+        ) { attempt ->
+            attempts += attempt
+            if (attempt < 3) throw SocketTimeoutException("T-Box did not answer")
+            "ready"
+        }
+
+        assertEquals("ready", result)
+        assertEquals(listOf(1, 2, 3), attempts)
+        assertEquals(listOf(1, 2), retryAttempts)
+        assertEquals(listOf(100L, 200L), delays)
+    }
+
+    @Test
+    fun `stops after the configured attempt budget`() = runBlocking {
+        val expected = IOException("connection reset")
+        var attempts = 0
+
+        try {
+            retryEasyConnStart(
+                policy = policy(),
+                shouldRetry = ::isTransientEasyConnFailure,
+                sleeper = { }
+            ) {
+                attempts++
+                throw expected
+            }
+            fail("The final failure must be returned")
+        } catch (failure: Throwable) {
+            assertSame(expected, failure)
+        }
+
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `does not retry permanent configuration failures`() = runBlocking {
+        val expected = IllegalStateException("host is not set or has not been found")
+        var attempts = 0
+
+        try {
+            retryEasyConnStart(
+                policy = policy(),
+                shouldRetry = ::isTransientEasyConnFailure,
+                sleeper = { fail("A permanent failure must not sleep") }
+            ) {
+                attempts++
+                throw expected
+            }
+            fail("The permanent failure must be returned")
+        } catch (failure: Throwable) {
+            assertSame(expected, failure)
+        }
+
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `propagates cancellation without retrying`() = runBlocking {
+        val expected = CancellationException("cancelled by user")
+        var attempts = 0
+
+        try {
+            retryEasyConnStart(
+                policy = policy(),
+                shouldRetry = { true },
+                sleeper = { fail("Cancellation must not sleep") }
+            ) {
+                attempts++
+                throw expected
+            }
+            fail("Cancellation must be propagated")
+        } catch (failure: Throwable) {
+            assertSame(expected, failure)
+        }
+
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `classifies Go timeout messages but rejects permanent startup errors`() {
+        assertTrue(isTransientEasyConnFailure(Exception("context deadline exceeded")))
+        assertTrue(isTransientEasyConnFailure(Exception("initialize EasyConn stream: no response")))
+        assertTrue(isTransientEasyConnFailure(IOException("network unreachable")))
+        assertFalse(isTransientEasyConnFailure(Exception("already running")))
+        assertFalse(isTransientEasyConnFailure(Exception("start reverse server 1: bind failed")))
+        assertFalse(isTransientEasyConnFailure(IOException("start reverse server 1: bind failed")))
+        assertFalse(isTransientEasyConnFailure(CancellationException("cancelled")))
+    }
+
+    private fun policy() = EasyConnRetryPolicy(
+        maxAttempts = 3,
+        initialDelayMillis = 100,
+        maximumDelayMillis = 250,
+        backoffMultiplier = 2
+    )
+}

--- a/documentation/ANDROID_IMPLEMENTATION.md
+++ b/documentation/ANDROID_IMPLEMENTATION.md
@@ -220,6 +220,13 @@ the adapter may use a same-subnet gateway/DNS address or, on an otherwise
 unrouted `/24`, derive the Wi-Fi Direct group owner at `.1`. It must not invent
 the service metadata when NSD itself fails.
 
+The EC command connection and reverse PXC startup use a three-attempt budget for
+transient timeouts, connection failures and temporary T-Box rejection. Delays
+are `750ms` and `1500ms`; cancellation, invalid session state and reverse-port
+bind failures are not retried. RideDaemon synchronously closes all listeners
+and accepted sockets from a failed attempt before Kotlin opens the next
+network-bound command socket.
+
 The operational fallback is the T-Box AP as primary Wi-Fi and source-app
 Internet through the mobile network. Reference:
 [WifiNetworkSuggestion](https://developer.android.com/reference/android/net/wifi/WifiNetworkSuggestion).


### PR DESCRIPTION
## Summary
- retry transient EasyConn startup failures up to three times
- use cancellable 750 ms and 1500 ms backoff delays
- keep permanent session and reverse-port errors single-attempt
- close the original Java command socket after transferring its duplicate to Go
- bump the candidate to 0.8.2-beta.7 (45)

## Verification
- 47 Android unit tests pass
- lintDebug and lintRelease pass with no errors
- debug and signed private Android Auto release builds pass
- Android Auto identity and APK signature verified

## Hardware gate
Do not merge until mirroring and Android Auto have both been validated on the primary motorcycle.