### PR TITLE
Add dynamic Android Auto orientation profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The app should continue to open normally. Only the related feature is unavailabl
 
 ## Current Status
 
-The current Android client is version `0.8.2-beta.7` (`45`) and targets Android 14/API 34 and newer.
+The current Android client is version `0.8.2-beta.8` (`46`) and targets Android 14/API 34 and newer.
 
 This build has been tested end-to-end for mirroring and Android Auto on a OnePlus 13 and a CFMOTO 700MT-ADV T-Box. Compatibility with other phones, motorcycle models, T-Box firmware versions, and Android Auto versions is not guaranteed and must be validated separately.
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "io.motohub.android"
         minSdk = 34
         targetSdk = 36
-        versionCode = 45
-        versionName = "0.8.2-beta.7"
+        versionCode = 46
+        versionName = "0.8.2-beta.8"
     }
 
     signingConfigs {

--- a/apps/android/app/src/main/java/io/motohub/android/aa/AaReceiver.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/aa/AaReceiver.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.view.Surface
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfile
 import java.net.ServerSocket
 import java.net.Socket
 import kotlin.concurrent.thread
@@ -21,6 +22,7 @@ class AaReceiver(
     private val onVideoReady: () -> Unit,
     private val onSessionEnded: (clean: Boolean) -> Unit,
     private val mapTouchToSource: (Int, Int) -> Pair<Int, Int>?,
+    private val capabilityProfile: AndroidAutoCapabilityProfile,
 ) {
     companion object {
         const val PORT = 5288
@@ -37,8 +39,8 @@ class AaReceiver(
     @Volatile private var videoReadyFired = false
     @Volatile private var input: AaInput? = null
     private val videoDecoder = VideoDecoder().apply {
-        fallbackWidth = ServiceDiscoveryResponse.AA_WIDTH
-        fallbackHeight = ServiceDiscoveryResponse.AA_HEIGHT
+        fallbackWidth = capabilityProfile.video.width
+        fallbackHeight = capabilityProfile.video.height
         onFirstFrameListener = {
             if (!videoReadyFired) {
                 videoReadyFired = true
@@ -121,7 +123,11 @@ class AaReceiver(
     private fun handleConnection(client: Socket) {
         val conn = SocketAccessoryConnection(client)
         connection = conn
-        val t = AapTransport(videoDecoder, context)
+        val t = AapTransport(
+            videoDecoder = videoDecoder,
+            context = context,
+            androidAutoCapabilityProfile = capabilityProfile
+        )
         t.onQuit = { clean ->
             log("[AA] transport quit (clean=$clean, userExit=${t.wasUserExit})")
             input = null

--- a/apps/android/app/src/main/java/io/motohub/android/aa/AapControl.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/aa/AapControl.kt
@@ -186,7 +186,15 @@ internal class AapControlService(private val aapTransport: AapTransport) : AapCo
 
     private fun serviceDiscoveryRequest(request: Control.ServiceDiscoveryRequest): Int {
         AaLog.i("Service Discovery Request: %s", request.phoneName)
-        aapTransport.send(ServiceDiscoveryResponse())
+        val profile = aapTransport.androidAutoCapabilityProfile
+        AaLog.i(
+            "Service Discovery AA profile: %dx%d @%ddpi (%s)",
+            profile.video.width,
+            profile.video.height,
+            profile.densityDpi,
+            profile.source.name
+        )
+        aapTransport.send(ServiceDiscoveryResponse(profile))
         return 0
     }
 

--- a/apps/android/app/src/main/java/io/motohub/android/aa/AapTransport.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/aa/AapTransport.kt
@@ -13,11 +13,15 @@ import android.os.Process
 import android.os.SystemClock
 import android.util.SparseIntArray
 import io.motohub.android.aa.proto.Control
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfile
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfiles
 
 class AapTransport(
     private val videoDecoder: VideoDecoder,
     private val context: Context,
-    private val externalSsl: AapSslContext? = null
+    private val externalSsl: AapSslContext? = null,
+    internal val androidAutoCapabilityProfile: AndroidAutoCapabilityProfile =
+        AndroidAutoCapabilityProfiles.fallback()
 ) {
     val ssl: AapSsl = externalSsl ?: AapSslContext(SingleKeyKeyManager(context))
 

--- a/apps/android/app/src/main/java/io/motohub/android/aa/AapVideo.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/aa/AapVideo.kt
@@ -9,7 +9,7 @@ internal class AapVideo(
     private val videoDecoder: VideoDecoder,
     private val onFrameCorrupted: () -> Unit
 ) {
-    // ~2MB is ample for 800x480 H.264 access units.
+    // ~2 MiB is ample for access units from the supported standard AA source profiles.
     private val messageBuffer = ByteBuffer.allocate(Messages.DEF_BUFFER_LENGTH * 16)
     private var isFrameCorrupt = false
     private var lastKeyframeRequestMs = 0L

--- a/apps/android/app/src/main/java/io/motohub/android/aa/ServiceDiscoveryResponse.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/aa/ServiceDiscoveryResponse.kt
@@ -4,20 +4,24 @@
 package io.motohub.android.aa
 
 import com.google.protobuf.Message
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfile
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfiles
+import io.motohub.android.androidauto.AndroidAutoVideoPreset
 import io.motohub.android.aa.proto.Common
 import io.motohub.android.aa.proto.Control
 import io.motohub.android.aa.proto.Media
 import io.motohub.android.aa.proto.Sensors
 
-class ServiceDiscoveryResponse
-    : AapMessage(Channel.ID_CTR, Control.ControlMsgType.MESSAGE_SERVICE_DISCOVERY_RESPONSE_VALUE, makeProto()) {
+class ServiceDiscoveryResponse(
+    profile: AndroidAutoCapabilityProfile = AndroidAutoCapabilityProfiles.fallback()
+) : AapMessage(
+    Channel.ID_CTR,
+    Control.ControlMsgType.MESSAGE_SERVICE_DISCOVERY_RESPONSE_VALUE,
+    makeProto(profile)
+) {
 
     companion object {
-        const val AA_WIDTH = 800
-        const val AA_HEIGHT = 480
-        private const val AA_DENSITY = 160
-
-        private fun makeProto(): Message {
+        private fun makeProto(profile: AndroidAutoCapabilityProfile): Message {
             val services = mutableListOf<Control.Service>()
 
             // --- Sensor service (driving status + night) ---
@@ -29,7 +33,7 @@ class ServiceDiscoveryResponse
                 }.build()
             }.build())
 
-            // --- Video service: fixed Android Auto source canvas, composed into T-Box VideoArea. ---
+            // --- Video service: standard AA source selected from the learned T-Box orientation. ---
             services.add(Control.Service.newBuilder().also { service ->
                 service.id = Channel.ID_VID
                 service.mediaSinkService = Control.Service.MediaSinkService.newBuilder().also { sink ->
@@ -38,12 +42,9 @@ class ServiceDiscoveryResponse
                     sink.availableWhileInCall = true
                     sink.addVideoConfigs(
                         Control.Service.MediaSinkService.VideoConfiguration.newBuilder().apply {
-                            codecResolution = Control.Service.MediaSinkService.VideoConfiguration
-                                .VideoCodecResolutionType._800x480
+                            codecResolution = profile.videoPreset.toProtocolResolution()
                             frameRate = Control.Service.MediaSinkService.VideoConfiguration.VideoFrameRateType._30
-                            setDensity(AA_DENSITY)
-                            // Keep the AAP contract byte-compatible with the proven OpenCfMoto
-                            // profile. TFT-specific fill/crop belongs exclusively to AaCompositor.
+                            setDensity(profile.densityDpi)
                             setMarginWidth(0)
                             setMarginHeight(0)
                             setVideoCodecType(Media.MediaCodecType.MEDIA_CODEC_VIDEO_H264_BP)
@@ -57,8 +58,8 @@ class ServiceDiscoveryResponse
                 service.id = Channel.ID_INP
                 service.inputSourceService = Control.Service.InputSourceService.newBuilder().also { inp ->
                     inp.touchscreen = Control.Service.InputSourceService.TouchConfig.newBuilder().apply {
-                        setWidth(AA_WIDTH)
-                        setHeight(AA_HEIGHT)
+                        setWidth(profile.video.width)
+                        setHeight(profile.video.height)
                     }.build()
                 }.build()
             }.build())
@@ -124,6 +125,14 @@ class ServiceDiscoveryResponse
 
         private fun makeSensorType(type: Sensors.SensorType): Control.Service.SensorSourceService.Sensor =
             Control.Service.SensorSourceService.Sensor.newBuilder().setType(type).build()
+
+        private fun AndroidAutoVideoPreset.toProtocolResolution():
+            Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType = when (this) {
+            AndroidAutoVideoPreset.LANDSCAPE_800X480 ->
+                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._800x480
+            AndroidAutoVideoPreset.PORTRAIT_720X1280 ->
+                Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280
+        }
 
         private const val VEHICLE_MAKE = "OpenCfMoto"
         private const val VEHICLE_MODEL = "MotoPlay"

--- a/apps/android/app/src/main/java/io/motohub/android/androidauto/AaCompositor.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/androidauto/AaCompositor.kt
@@ -13,7 +13,6 @@ import android.opengl.Matrix
 import android.os.Handler
 import android.os.HandlerThread
 import android.view.Surface
-import io.motohub.android.aa.ServiceDiscoveryResponse
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.FloatBuffer
@@ -22,7 +21,8 @@ import java.util.concurrent.CountDownLatch
 /** GPU compositor that fills the TFT while keeping the complete source in the phone preview. */
 class AaCompositor(
     private val log: (String) -> Unit,
-    private val displayMode: AndroidAutoDisplayMode
+    private val displayMode: AndroidAutoDisplayMode,
+    private val sourceGeometry: DisplayGeometry
 ) {
     private val thread = HandlerThread("aa-compositor").apply { start() }
     private val handler = Handler(thread.looper)
@@ -88,16 +88,15 @@ class AaCompositor(
                 initGl()
                 surfaceTexture = SurfaceTexture(textureId).apply {
                     setDefaultBufferSize(
-                        ServiceDiscoveryResponse.AA_WIDTH,
-                        ServiceDiscoveryResponse.AA_HEIGHT
+                        sourceGeometry.width,
+                        sourceGeometry.height
                     )
                     setOnFrameAvailableListener({ handler.post(::onFrame) }, handler)
                 }
                 inputSurface = Surface(surfaceTexture)
                 handler.postDelayed(keepAlive, KEEPALIVE_INTERVAL_MS)
                 log(
-                    "[COMPOSITOR] ready source=${ServiceDiscoveryResponse.AA_WIDTH}x" +
-                        "${ServiceDiscoveryResponse.AA_HEIGHT}"
+                    "[COMPOSITOR] ready source=${sourceGeometry.width}x${sourceGeometry.height}"
                 )
             } catch (failure: Throwable) {
                 log("[COMPOSITOR] init failed: $failure")
@@ -207,8 +206,8 @@ class AaCompositor(
     )
 
     private fun previewSourceGeometry() = DisplayGeometry(
-        width = srcW.takeIf { it > 0 } ?: ServiceDiscoveryResponse.AA_WIDTH,
-        height = srcH.takeIf { it > 0 } ?: ServiceDiscoveryResponse.AA_HEIGHT
+        width = srcW.takeIf { it > 0 } ?: sourceGeometry.width,
+        height = srcH.takeIf { it > 0 } ?: sourceGeometry.height
     )
 
     private fun onFrame() {

--- a/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoCapabilityProfile.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoCapabilityProfile.kt
@@ -1,0 +1,67 @@
+package io.motohub.android.androidauto
+
+enum class AndroidAutoVideoPreset(
+    val source: DisplayGeometry,
+    val densityDpi: Int
+) {
+    LANDSCAPE_800X480(DisplayGeometry(800, 480), 160),
+    PORTRAIT_720X1280(DisplayGeometry(720, 1280), 240)
+}
+
+enum class AndroidAutoCapabilitySource {
+    FALLBACK,
+    SAVED_TBOX_GEOMETRY
+}
+
+data class AndroidAutoCapabilityProfile(
+    val videoPreset: AndroidAutoVideoPreset,
+    val source: AndroidAutoCapabilitySource,
+    val target: DisplayGeometry?,
+    val reason: String
+) {
+    val video: DisplayGeometry get() = videoPreset.source
+    val densityDpi: Int get() = videoPreset.densityDpi
+}
+
+object AndroidAutoCapabilityProfiles {
+    fun select(target: DisplayGeometry?): AndroidAutoCapabilityProfile {
+        if (target == null) return fallback("No saved T-Box geometry is available.")
+        if (!target.isPlausibleTBoxGeometry()) {
+            return fallback(
+                "Saved T-Box geometry ${target.width}x${target.height} is outside safe limits."
+            )
+        }
+
+        val preset = if (target.height > target.width) {
+            AndroidAutoVideoPreset.PORTRAIT_720X1280
+        } else {
+            AndroidAutoVideoPreset.LANDSCAPE_800X480
+        }
+        return AndroidAutoCapabilityProfile(
+            videoPreset = preset,
+            source = AndroidAutoCapabilitySource.SAVED_TBOX_GEOMETRY,
+            target = target,
+            reason = "Selected from saved runtime T-Box geometry ${target.width}x${target.height}."
+        )
+    }
+
+    fun fallback(reason: String = "Using the hardware-validated compatibility profile.") =
+        AndroidAutoCapabilityProfile(
+            videoPreset = AndroidAutoVideoPreset.LANDSCAPE_800X480,
+            source = AndroidAutoCapabilitySource.FALLBACK,
+            target = null,
+            reason = reason
+        )
+
+    private fun DisplayGeometry.isPlausibleTBoxGeometry(): Boolean {
+        val shortest = minOf(width, height)
+        val longest = maxOf(width, height)
+        return shortest in MIN_DIMENSION..MAX_DIMENSION &&
+            longest in MIN_DIMENSION..MAX_DIMENSION &&
+            longest <= shortest * MAX_ASPECT_RATIO
+    }
+
+    private const val MIN_DIMENSION = 240
+    private const val MAX_DIMENSION = 4096
+    private const val MAX_ASPECT_RATIO = 4
+}

--- a/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoDisplayProfile.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoDisplayProfile.kt
@@ -61,24 +61,25 @@ internal fun calculateAndroidAutoDisplayProfile(
 private fun even(value: Int): Int = value and 1.inv()
 
 object ActiveAndroidAutoDisplayProfile {
+    private const val AAP_CANVAS_WIDTH = 800
+    private const val AAP_CANVAS_HEIGHT = 480
+    private val DEFAULT_SOURCE = DisplayGeometry(AAP_CANVAS_WIDTH, AAP_CANVAS_HEIGHT)
+
     @Volatile
     var current: AndroidAutoDisplayProfile = calculateAndroidAutoDisplayProfile(uncalibratedGeometry())
         private set
 
-    fun configure(target: DisplayGeometry): AndroidAutoDisplayProfile =
-        calculateAndroidAutoDisplayProfile(target).also { current = it }
+    fun configure(
+        target: DisplayGeometry,
+        source: DisplayGeometry = DEFAULT_SOURCE
+    ): AndroidAutoDisplayProfile =
+        calculateAndroidAutoDisplayProfile(target, source).also { current = it }
 
-    /**
-     * Android Auto's fixed source canvas. This is not a motorcycle display size: without a
-     * negotiated T-Box [DisplayGeometry], keeping the whole source visible is the only neutral
-     * choice. A real area is persisted as soon as the T-Box advertises VideoArea.
-     */
-    fun configureUncalibrated(): AndroidAutoDisplayProfile = configure(uncalibratedGeometry())
+    /** Keeps the complete selected AA source visible until a T-Box geometry is available. */
+    fun configureUncalibrated(source: DisplayGeometry = DEFAULT_SOURCE): AndroidAutoDisplayProfile =
+        configure(source, source)
 
-    private fun uncalibratedGeometry() = DisplayGeometry(AAP_CANVAS_WIDTH, AAP_CANVAS_HEIGHT)
-
-    private const val AAP_CANVAS_WIDTH = 800
-    private const val AAP_CANVAS_HEIGHT = 480
+    private fun uncalibratedGeometry() = DEFAULT_SOURCE
 }
 
 class TBoxDisplayGeometryStore(context: Context) {

--- a/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoSessionService.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/androidauto/AndroidAutoSessionService.kt
@@ -16,7 +16,6 @@ import io.motohub.android.MainActivity
 import io.motohub.android.R
 import io.motohub.android.aa.AaReceiver
 import io.motohub.android.aa.SingleKeyKeyManager
-import io.motohub.android.aa.ServiceDiscoveryResponse
 import io.motohub.android.encoding.AvcEncoder
 import io.motohub.android.encoding.EncoderProfile
 import io.motohub.android.session.ProjectionEventLog
@@ -53,6 +52,7 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
     private val transportUnavailable = AtomicBoolean(false)
     private val videoStreamStartRequested = AtomicBoolean(false)
     private val framesAccepted = AtomicLong(0)
+    private var capabilityProfile = AndroidAutoCapabilityProfiles.fallback()
 
     @Volatile
     private var stopping = false
@@ -85,9 +85,17 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
             ?: return fail("No T-Box is ready. Connect and find the T-Box before starting Android Auto.")
         tBoxHandle = handle
         val learnedGeometry = displayGeometryStore.load(handle.motorcycle.ssid)
+        capabilityProfile = AndroidAutoCapabilityProfiles.select(learnedGeometry)
         val learnedCanvas = learnedGeometry?.let(::alignedCanvasGeometry)
-        val displayProfile = learnedCanvas?.let(ActiveAndroidAutoDisplayProfile::configure)
-            ?: ActiveAndroidAutoDisplayProfile.configureUncalibrated()
+        val displayProfile = learnedCanvas?.let { target ->
+            ActiveAndroidAutoDisplayProfile.configure(target, capabilityProfile.video)
+        } ?: ActiveAndroidAutoDisplayProfile.configureUncalibrated(capabilityProfile.video)
+        ProjectionEventLog.record(
+            "ANDROID AUTO",
+            "Capability profile: source=${capabilityProfile.video.width}x" +
+                "${capabilityProfile.video.height}@${capabilityProfile.densityDpi}dpi, " +
+                "selection=${capabilityProfile.source}; ${capabilityProfile.reason}"
+        )
         if (learnedGeometry == null) {
             ProjectionEventLog.record(
                 "ANDROID AUTO",
@@ -115,7 +123,7 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
                 "ANDROID AUTO",
                 "TFT display mode selected for ${handle.motorcycle.ssid}: $displayMode."
             )
-            val activeCompositor = AaCompositor(::log, displayMode)
+            val activeCompositor = AaCompositor(::log, displayMode, capabilityProfile.video)
             activeCompositor.start()
             val decoderSurface = activeCompositor.inputSurface
                 ?: error("Android Auto compositor did not create the video surface")
@@ -143,7 +151,8 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
                         }
                     }
                 },
-                mapTouchToSource = activeCompositor::mapCanvasToSource
+                mapTouchToSource = activeCompositor::mapCanvasToSource,
+                capabilityProfile = capabilityProfile
             )
             if (!SingleKeyKeyManager.isAvailable(applicationContext)) {
                 error(
@@ -216,7 +225,20 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
                     "${actualGeometry.width}x${actualGeometry.height}."
             )
         }
-        ActiveAndroidAutoDisplayProfile.configure(actualGeometry)
+        ActiveAndroidAutoDisplayProfile.configure(actualGeometry, capabilityProfile.video)
+        val learnedCapability = AndroidAutoCapabilityProfiles.select(
+            DisplayGeometry(negotiatedArea.width, negotiatedArea.height)
+        )
+        if (learnedCapability.videoPreset != capabilityProfile.videoPreset) {
+            ProjectionEventLog.warning(
+                "ANDROID AUTO",
+                "The live TFT geometry recommends ${learnedCapability.video.width}x" +
+                    "${learnedCapability.video.height}@${learnedCapability.densityDpi}dpi. " +
+                    "The current AAP session remains ${capabilityProfile.video.width}x" +
+                    "${capabilityProfile.video.height}; the learned profile will be used automatically " +
+                    "the next time Android Auto starts."
+            )
+        }
         ProjectionEventLog.record(
             "T-BOX",
             "Area Android Auto ${encoderProfile.width}x${encoderProfile.height}."
@@ -255,8 +277,8 @@ class AndroidAutoSessionService : Service(), AndroidAutoPreviewController {
                 encoderSurface,
                 encoderProfile.width,
                 encoderProfile.height,
-                ServiceDiscoveryResponse.AA_WIDTH,
-                ServiceDiscoveryResponse.AA_HEIGHT
+                capabilityProfile.video.width,
+                capabilityProfile.video.height
             )
             AndroidAutoRuntime.publish(AndroidAutoRuntimeState.Streaming)
             ProjectionRuntime.publish(ProjectionRuntimeState.Streaming)

--- a/apps/android/app/src/test/java/io/motohub/android/aa/ServiceDiscoveryResponseTest.kt
+++ b/apps/android/app/src/test/java/io/motohub/android/aa/ServiceDiscoveryResponseTest.kt
@@ -1,7 +1,9 @@
 package io.motohub.android.aa
 
 import io.motohub.android.aa.proto.Control
-import io.motohub.android.androidauto.ActiveAndroidAutoDisplayProfile
+import io.motohub.android.androidauto.AndroidAutoCapabilityProfiles
+import io.motohub.android.androidauto.AndroidAutoCapabilitySource
+import io.motohub.android.androidauto.AndroidAutoVideoPreset
 import io.motohub.android.androidauto.DisplayGeometry
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -32,13 +34,20 @@ class ServiceDiscoveryResponseTest {
         assertEquals(160, video.density)
         assertEquals(0, video.marginWidth)
         assertEquals(0, video.marginHeight)
+
+        val touch = response.servicesList
+            .first { it.id == Channel.ID_INP }
+            .inputSourceService
+            .touchscreen
+        assertEquals(800, touch.width)
+        assertEquals(480, touch.height)
     }
 
     @Test
-    fun tftGeometryCannotChangeTheAapCompatibilityContract() {
-        ActiveAndroidAutoDisplayProfile.configure(DisplayGeometry(800, 386))
+    fun advertisesPortraitVideoAndTouchFromTheSelectedCapabilityProfile() {
+        val profile = AndroidAutoCapabilityProfiles.select(DisplayGeometry(800, 944))
 
-        val response = ServiceDiscoveryResponse()
+        val response = ServiceDiscoveryResponse(profile)
             .parse(Control.ServiceDiscoveryResponse.newBuilder())
             .build()
         val video = response.servicesList
@@ -47,7 +56,19 @@ class ServiceDiscoveryResponseTest {
             .videoConfigsList
             .single()
 
-        assertEquals(0, video.marginWidth)
-        assertEquals(0, video.marginHeight)
+        assertEquals(
+            Control.Service.MediaSinkService.VideoConfiguration.VideoCodecResolutionType._720x1280,
+            video.codecResolution
+        )
+        assertEquals(240, video.density)
+        assertEquals(AndroidAutoVideoPreset.PORTRAIT_720X1280, profile.videoPreset)
+        assertEquals(AndroidAutoCapabilitySource.SAVED_TBOX_GEOMETRY, profile.source)
+
+        val touch = response.servicesList
+            .first { it.id == Channel.ID_INP }
+            .inputSourceService
+            .touchscreen
+        assertEquals(720, touch.width)
+        assertEquals(1280, touch.height)
     }
 }

--- a/apps/android/app/src/test/java/io/motohub/android/androidauto/AndroidAutoCapabilityProfileTest.kt
+++ b/apps/android/app/src/test/java/io/motohub/android/androidauto/AndroidAutoCapabilityProfileTest.kt
@@ -1,0 +1,50 @@
+package io.motohub.android.androidauto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AndroidAutoCapabilityProfileTest {
+    @Test
+    fun `uses the validated landscape fallback when geometry is unavailable`() {
+        val profile = AndroidAutoCapabilityProfiles.select(null)
+
+        assertEquals(AndroidAutoVideoPreset.LANDSCAPE_800X480, profile.videoPreset)
+        assertEquals(AndroidAutoCapabilitySource.FALLBACK, profile.source)
+        assertEquals(DisplayGeometry(800, 480), profile.video)
+        assertEquals(160, profile.densityDpi)
+        assertNull(profile.target)
+    }
+
+    @Test
+    fun `keeps the validated landscape profile for a landscape T-Box`() {
+        val target = DisplayGeometry(1280, 576)
+
+        val profile = AndroidAutoCapabilityProfiles.select(target)
+
+        assertEquals(AndroidAutoVideoPreset.LANDSCAPE_800X480, profile.videoPreset)
+        assertEquals(AndroidAutoCapabilitySource.SAVED_TBOX_GEOMETRY, profile.source)
+        assertEquals(target, profile.target)
+    }
+
+    @Test
+    fun `selects the standard portrait profile for a portrait T-Box`() {
+        val target = DisplayGeometry(800, 944)
+
+        val profile = AndroidAutoCapabilityProfiles.select(target)
+
+        assertEquals(AndroidAutoVideoPreset.PORTRAIT_720X1280, profile.videoPreset)
+        assertEquals(AndroidAutoCapabilitySource.SAVED_TBOX_GEOMETRY, profile.source)
+        assertEquals(DisplayGeometry(720, 1280), profile.video)
+        assertEquals(240, profile.densityDpi)
+        assertEquals(target, profile.target)
+    }
+
+    @Test
+    fun `rejects implausible saved geometry instead of changing the AAP contract`() {
+        val profile = AndroidAutoCapabilityProfiles.select(DisplayGeometry(100, 900))
+
+        assertEquals(AndroidAutoVideoPreset.LANDSCAPE_800X480, profile.videoPreset)
+        assertEquals(AndroidAutoCapabilitySource.FALLBACK, profile.source)
+    }
+}

--- a/apps/android/app/src/test/java/io/motohub/android/androidauto/PreviewGeometryTest.kt
+++ b/apps/android/app/src/test/java/io/motohub/android/androidauto/PreviewGeometryTest.kt
@@ -32,4 +32,32 @@ class PreviewGeometryTest {
         assertEquals(799 to 479, viewport.mapToSource(1528, 606))
         assertNull(viewport.mapToSource(517, 300))
     }
+
+    @Test
+    fun `portrait source maps preview touches without rotating coordinates`() {
+        val portraitSource = DisplayGeometry(720, 1280)
+        val viewport = calculatePreviewViewport(DisplayGeometry(1080, 1920), portraitSource)
+
+        assertEquals(0, viewport.x)
+        assertEquals(0, viewport.y)
+        assertEquals(1080, viewport.width)
+        assertEquals(1920, viewport.height)
+        assertEquals(0 to 0, viewport.mapToSource(0, 0))
+        assertEquals(719 to 1279, viewport.mapToSource(1079, 1919))
+    }
+
+    @Test
+    fun `portrait source maps T-Box touches and rejects side bars`() {
+        val portraitSource = DisplayGeometry(720, 1280)
+        val viewport = calculatePreviewViewport(DisplayGeometry(800, 944), portraitSource)
+
+        assertEquals(134, viewport.x)
+        assertEquals(0, viewport.y)
+        assertEquals(531, viewport.width)
+        assertEquals(944, viewport.height)
+        assertNull(viewport.mapToSource(133, 472))
+        assertEquals(0 to 0, viewport.mapToSource(134, 0))
+        assertEquals(718 to 1278, viewport.mapToSource(664, 943))
+        assertNull(viewport.mapToSource(665, 472))
+    }
 }

--- a/documentation/DYNAMIC_ANDROID_AUTO_PROFILE.md
+++ b/documentation/DYNAMIC_ANDROID_AUTO_PROFILE.md
@@ -1,6 +1,7 @@
 # Dynamic Android Auto Capability Profile
 
-Status: implemented in `0.8.2-beta.8`; physical portrait TFT validation pending.
+Status: landscape hardware validation passed in `0.8.2-beta.8`; physical
+portrait TFT validation pending.
 
 MOTO-HUB selects one standard Android Auto source profile before the local AAP
 handshake:

--- a/documentation/DYNAMIC_ANDROID_AUTO_PROFILE.md
+++ b/documentation/DYNAMIC_ANDROID_AUTO_PROFILE.md
@@ -1,0 +1,32 @@
+# Dynamic Android Auto Capability Profile
+
+Status: implemented in `0.8.2-beta.8`; physical portrait TFT validation pending.
+
+MOTO-HUB selects one standard Android Auto source profile before the local AAP
+handshake:
+
+| Learned T-Box geometry | Android Auto source | Density |
+|---|---:|---:|
+| Missing, invalid or landscape | `800x480` | 160 dpi |
+| Portrait | `720x1280` | 240 dpi |
+
+The selection uses only the runtime `VideoArea` saved for the same T-Box SSID.
+It never infers a motorcycle model from QR metadata, SSID naming or marketing
+names. Exact T-Box dimensions still configure the encoder and compositor.
+
+The profile is immutable for an active AAP session so service discovery,
+decoder fallback, compositor input and touch coordinates always agree. If a
+different orientation is learned during the first session, it is persisted and
+used automatically at the next Android Auto start. Restarting AAP mid-session
+is deliberately avoided.
+
+`800x480@160` remains the hardware-validated fallback and keeps the beta.7
+landscape behavior byte-compatible. Android Auto identity, EasyConn transport
+and the mirroring pipeline are unchanged.
+
+## Validation Gate
+
+- Ten Android Auto start/stop cycles on the validated landscape motorcycle.
+- Stable projection and phone-preview touch mapping on a portrait TFT.
+- Invalid or absent saved geometry selects `800x480@160`.
+- Mirroring regression test on the validated landscape motorcycle.

--- a/documentation/OPEN_CFMOTO_COMPARATIVE_AUDIT.md
+++ b/documentation/OPEN_CFMOTO_COMPARATIVE_AUDIT.md
@@ -221,15 +221,15 @@ OpenCfMoto advantage:
 
 Important MOTO-HUB constraint:
 
-MOTO-HUB currently advertises the proven `800x480@160` Android Auto source and
-composes it into the runtime T-Box canvas. Its compatibility identity values
-must not be renamed or modernized casually: a previous identity change caused
-Android Auto startup failure. A future dynamic source-resolution feature must
-preserve this complete profile as the default and be validated profile by
-profile on physical hardware.
+Starting with the beta.8 candidate, MOTO-HUB selects `800x480@160` for a saved
+landscape T-Box geometry and `720x1280@240` for a saved portrait geometry.
+Missing or invalid geometry still selects the hardware-validated landscape
+profile. The compatibility identity remains unchanged. Portrait support must
+remain marked unvalidated until it passes on physical hardware.
 
-Verdict: tie at the protocol-feature level. MOTO-HUB is better integrated and
-supportable; OpenCfMoto currently has broader known orientation profiles.
+Verdict: MOTO-HUB now has the stronger profile-selection design because it uses
+runtime geometry rather than motorcycle identifiers. OpenCfMoto retains the
+advantage of existing portrait hardware validation.
 
 ### 6. Mirroring and Phone Interaction
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -24,6 +24,7 @@ final app.
 | [TEST_STRATEGY.md](TEST_STRATEGY.md) | Software test strategy and hardware matrix |
 | [ROADMAP.md](ROADMAP.md) | Spikes, MVP, later phases and decision gates |
 | [RISK_REGISTER.md](RISK_REGISTER.md) | Open risks, impact and mitigations |
+| [DYNAMIC_ANDROID_AUTO_PROFILE.md](DYNAMIC_ANDROID_AUTO_PROFILE.md) | Runtime Android Auto orientation profiles and fallback contract |
 | [decisions/README.md](decisions/README.md) | Architecture decision record index |
 
 ## Reference Repositories


### PR DESCRIPTION
## Summary
- select the standard Android Auto source profile from saved runtime T-Box geometry
- preserve the hardware-validated 800x480@160 landscape fallback
- add 720x1280@240 portrait service discovery, decoder, compositor, preview, and touch mapping
- keep Android Auto identity, EasyConn transport, and mirroring unchanged

## Validation
- Android lint passed
- 53 unit tests passed
- signed private release APK verified
- 0.8.2-beta.8 (46) validated on OnePlus 13 / Android 16 and CFMOTO 700MT-ADV
- Android Auto, phone preview, clean stop, reconnect, and mirroring passed
- portrait TFT hardware validation remains pending

Hardware-tested code is tagged motohub-beta8-hardware-validated.