### PR TITLE
Handlebar HID input mode, phone-only Android Auto in Core UI, and calibration fixes

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -94,6 +94,26 @@
             android:exported="true"
             android:foregroundServiceType="connectedDevice" />
 
+        <!--
+            Optional: only acts while Handlebar buttons -> Input protocol is set to HID AND the
+            rider has separately granted Accessibility for MOTO-HUB in system settings (an
+            explicit grant Android requires; see HandlebarHidCaptureService.openAccessibilitySettings).
+            Lets a Bluetooth HID-keyboard handlebar remote's D-pad presses reach the app no matter
+            which app has focus on the TFT — D-pad keycodes are ordinary input events, unlike the
+            AVRCP media keys MediaButtonBridge reads through a MediaSession.
+        -->
+        <service
+            android:name=".feature.controls.HandlebarHidCaptureService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/handlebar_hid_capture_service" />
+        </service>
+
         <service
             android:name=".ipc.IpcBridgeService"
             android:exported="true"

--- a/apps/android/app/src/main/java/io/motohub/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/MainActivity.kt
@@ -71,6 +71,7 @@ import io.motohub.android.feature.home.HubViewModel
 import io.motohub.android.feature.androidauto.AndroidAutoHelpScreen
 import io.motohub.android.feature.androidauto.AndroidAutoPreviewScreen
 import io.motohub.android.feature.androidauto.OfficialCfmotoWarningDialog
+import io.motohub.android.feature.controls.HandlebarTeachPrerequisiteRequest
 import io.motohub.android.feature.diagnostics.NetworkDiagnosticsScreen
 import io.motohub.android.feature.diagnostics.NetworkDiagnosticsViewModel
 import io.motohub.android.feature.diagnostics.ApplicationLogScreen
@@ -466,7 +467,44 @@ class MainActivity : ComponentActivity() {
                 var androidAutoPermissionPending by rememberSaveable { mutableStateOf(false) }
                 var showOfficialCfmotoWarning by rememberSaveable { mutableStateOf(false) }
                 var externalDisplayPermissionPending by rememberSaveable { mutableStateOf(false) }
+                // Mirrors androidAutoPermissionPending for the phone-only path (see
+                // startPhoneOnlyBridge below) - a real T-Box session and a phone-only one both
+                // post a media notification for the same MediaButtonBridge/handlebar reason, so
+                // both need POST_NOTIFICATIONS before starting, not just the T-Box one.
+                var phoneOnlyAndroidAutoPermissionPending by rememberSaveable { mutableStateOf(false) }
+                // Set right before the permission chain starts (see continueAndroidAutoPhoneOnlyStart)
+                // and read once the bridge actually starts, on either side of a permission
+                // request round-trip. The handlebar teach dialog wants the session running
+                // silently in the background - captureActive is all it needs - and opening the
+                // full-screen preview there just hands the rider a "Close" button they can hit
+                // by accident and kill the very session they asked for.
+                var phoneOnlyAndroidAutoShowPreview by rememberSaveable { mutableStateOf(true) }
                 var microphonePermissionAction by rememberSaveable { mutableStateOf<String?>(null) }
+                // Starts the phone-only bridge itself - permission checks (notification, mic)
+                // happen in continueAndroidAutoPhoneOnlyStart below, exactly like
+                // continueAndroidAutoStart does for the real T-Box path. Skipping them here was
+                // the field bug reported 2026-08-13: without RECORD_AUDIO, invoking Android
+                // Auto's Assistant left it waiting on a microphone stream that never arrived,
+                // and every handlebar press after that point silently did nothing.
+                val startPhoneOnlyBridge: () -> Unit = {
+                    ProjectionEventLog.record(
+                        "ANDROID_AUTO",
+                        "User started phone-only Android Auto (no T-Box) for testing."
+                    )
+                    // Same bridge Advanced's own "Android Auto - straight to your phone" card
+                    // starts over IPC (see PhoneOnlyAndroidAutoLaunchRequest) - here it's an
+                    // in-process button tap instead of a launch Intent. Deliberately NOT
+                    // androidAutoPhoneOnlyLaunchedFromPro: that flag finish()es this Activity
+                    // when the preview closes, which is right for a launch FROM Advanced but
+                    // would exit Core's own UI for a tap made inside it.
+                    androidAutoPhoneOnlyBridge.start(onFailure = { message ->
+                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                    })
+                    androidAutoPreviewIsPhoneOnly = true
+                    if (phoneOnlyAndroidAutoShowPreview) {
+                        showAndroidAutoPreview = true
+                    }
+                }
                 val microphonePermissionLauncher = rememberLauncherForActivityResult(
                     ActivityResultContracts.RequestPermission()
                 ) { granted ->
@@ -476,6 +514,7 @@ class MainActivity : ComponentActivity() {
                     if (granted) {
                         when (action) {
                             "full" -> startAndroidAuto()
+                            "phone_only" -> startPhoneOnlyBridge()
                         }
                     }
                 }
@@ -486,6 +525,16 @@ class MainActivity : ComponentActivity() {
                         startAndroidAuto()
                     } else {
                         microphonePermissionAction = action
+                        microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                    }
+                }
+                val requestMicAndStartPhoneOnly: () -> Unit = {
+                    if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+                        PackageManager.PERMISSION_GRANTED
+                    ) {
+                        startPhoneOnlyBridge()
+                    } else {
+                        microphonePermissionAction = "phone_only"
                         microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                     }
                 }
@@ -514,6 +563,13 @@ class MainActivity : ComponentActivity() {
                         } else {
                             viewModel.onNotificationPermissionDenied()
                         }
+                    } else if (phoneOnlyAndroidAutoPermissionPending) {
+                        phoneOnlyAndroidAutoPermissionPending = false
+                        if (granted) {
+                            requestMicAndStartPhoneOnly()
+                        } else {
+                            viewModel.onNotificationPermissionDenied()
+                        }
                     }
                 }
                 val continueAndroidAutoStart: () -> Unit = {
@@ -526,6 +582,22 @@ class MainActivity : ComponentActivity() {
                         requestMicAndStart("full")
                     } else {
                         androidAutoPermissionPending = true
+                        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                }
+                // Same permission sequence as continueAndroidAutoStart (notification, then mic)
+                // for the phone-only path - see startPhoneOnlyBridge for why skipping this was a bug.
+                val continueAndroidAutoPhoneOnlyStart: (Boolean) -> Unit = { showPreview ->
+                    phoneOnlyAndroidAutoShowPreview = showPreview
+                    val notificationGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) == PackageManager.PERMISSION_GRANTED
+                    if (notificationGranted) {
+                        requestMicAndStartPhoneOnly()
+                    } else {
+                        phoneOnlyAndroidAutoPermissionPending = true
                         notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                     }
                 }
@@ -569,6 +641,39 @@ class MainActivity : ComponentActivity() {
                         connectWhenAndroidAccepts("after the Wi-Fi permission grant")
                     } else {
                         viewModel.onNearbyWifiPermissionDenied()
+                    }
+                }
+                // Same permission-check-then-connect sequence HubHomeScreen's own Connect
+                // button uses (see onConnectAndDiscover below) - pulled out so the handlebar
+                // teach prerequisite dialog (see HandlebarTeachPrerequisiteRequest) can reuse it
+                // after selecting a different motorcycle, instead of duplicating the check.
+                val connectToActiveMotorcycle: () -> Unit = {
+                    val permissions =
+                        tboxConnectPermissions(viewModel.uiState.value.session.motorcycle)
+                    if (permissions.all { permission ->
+                            ContextCompat.checkSelfPermission(context, permission) ==
+                                PackageManager.PERMISSION_GRANTED
+                        }
+                    ) {
+                        connectWhenAndroidAccepts("Connect button")
+                    } else {
+                        wifiPermissionLauncher.launch(permissions)
+                    }
+                }
+                LaunchedEffect(Unit) {
+                    HandlebarTeachPrerequisiteRequest.requests.collect { choice ->
+                        when (choice) {
+                            HandlebarTeachPrerequisiteRequest.Choice.PhoneOnly ->
+                                // Silent: calibration only needs captureActive, and a fresh
+                                // rider seeing an unexpected full-screen preview open here
+                                // could tap its "Close" button without realizing that stops
+                                // the very session they just asked for.
+                                continueAndroidAutoPhoneOnlyStart(false)
+                            is HandlebarTeachPrerequisiteRequest.Choice.Connect -> {
+                                viewModel.selectMotorcycle(choice.motorcycleId)
+                                connectToActiveMotorcycle()
+                            }
+                        }
                     }
                 }
                 fun reconnectAfterModeStop(mode: String) {
@@ -872,14 +977,24 @@ class MainActivity : ComponentActivity() {
                     AndroidAutoPreviewScreen(
                         onBack = {
                             ProjectionEventLog.record("UI", "Android Auto phone preview closed.")
-                            if (androidAutoPreviewIsPhoneOnly) {
-                                androidAutoPhoneOnlyBridge.stop()
-                            }
-                            showAndroidAutoPreview = false
-                            androidAutoPreviewIsPhoneOnly = false
                             if (androidAutoPhoneOnlyLaunchedFromPro) {
+                                // Advanced launched Core just for this preview - closing it IS
+                                // closing the whole point of this Activity instance.
+                                androidAutoPhoneOnlyBridge.stop()
+                                showAndroidAutoPreview = false
+                                androidAutoPreviewIsPhoneOnly = false
                                 androidAutoPhoneOnlyLaunchedFromPro = false
                                 finish()
+                            } else {
+                                // Otherwise this is closing the PREVIEW, not the session: a
+                                // phone-only test session (and its handlebar capture) keeps
+                                // running in the background exactly like a real T-Box session
+                                // does when the rider switches tabs - HubDestination.ACTIVE_SESSION
+                                // picks it up from the same AndroidAutoRuntime state either way,
+                                // with its own "reopen preview" and explicit Stop actions.
+                                // androidAutoPreviewIsPhoneOnly deliberately stays true so
+                                // onStopAndroidAuto knows which session that Stop belongs to.
+                                showAndroidAutoPreview = false
                             }
                         }
                     )
@@ -1061,19 +1176,7 @@ class MainActivity : ComponentActivity() {
                             viewModel.preparePhoneHotspotRetry()
                             showManualPairing = true
                         },
-                        onConnectAndDiscover = {
-                            val permissions =
-                                tboxConnectPermissions(viewModel.uiState.value.session.motorcycle)
-                            if (permissions.all { permission ->
-                                    ContextCompat.checkSelfPermission(context, permission) ==
-                                        PackageManager.PERMISSION_GRANTED
-                                }
-                            ) {
-                                connectWhenAndroidAccepts("Connect button")
-                            } else {
-                                wifiPermissionLauncher.launch(permissions)
-                            }
-                        },
+                        onConnectAndDiscover = connectToActiveMotorcycle,
                         officialCfmotoAppInstalled = OfficialCfmotoClient.isInstalled(context),
                         onCloseOfficialCfmotoAndRetry = {
                             // Android 14+ cannot close another app's process; this action is a
@@ -1125,13 +1228,21 @@ class MainActivity : ComponentActivity() {
                         onStartAndroidAuto = startAndroidAutoWithWarning,
                         onStopAndroidAuto = {
                             ProjectionEventLog.record("ANDROID_AUTO", "User requested Android Auto stop.")
-                            AndroidAutoSessionService.stop(context)
-                            reconnectAfterModeStop("Android Auto")
+                            if (androidAutoPreviewIsPhoneOnly) {
+                                // No T-Box link to reconnect for a phone-only session -
+                                // reconnectAfterModeStop is specifically for the real T-Box path.
+                                androidAutoPhoneOnlyBridge.stop()
+                                androidAutoPreviewIsPhoneOnly = false
+                            } else {
+                                AndroidAutoSessionService.stop(context)
+                                reconnectAfterModeStop("Android Auto")
+                            }
                         },
                         onOpenAndroidAutoPreview = {
                             ProjectionEventLog.record("UI", "Android Auto phone preview opened.")
                             showAndroidAutoPreview = true
                         },
+                        onStartPhoneOnlyAndroidAuto = { continueAndroidAutoPhoneOnlyStart(true) },
                         dimDisplayEnabled = dimDisplayEnabled,
                         onDimDisplayChanged = { enabled ->
                             ProjectionEventLog.record("DISPLAY", "User changed display dimmer preference to enabled=$enabled.")

--- a/apps/android/app/src/main/java/io/motohub/android/androidauto/PhoneOnlyAndroidAutoBridge.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/androidauto/PhoneOnlyAndroidAutoBridge.kt
@@ -5,6 +5,8 @@ import android.view.Surface
 import io.motohub.android.aa.AaReceiver
 import io.motohub.android.aa.AaSelfMode
 import io.motohub.android.aa.SingleKeyKeyManager
+import io.motohub.android.feature.controls.HandlebarControlStore
+import io.motohub.android.feature.controls.MediaButtonBridge
 import io.motohub.android.session.MotorcycleProfile
 import io.motohub.android.session.ProjectionEventLog
 import kotlinx.coroutines.CoroutineScope
@@ -56,6 +58,14 @@ class PhoneOnlyAndroidAutoBridge(private val context: Context) :
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var compositor: AaCompositor? = null
     private var receiver: AaReceiver? = null
+    // Same TARGET_ANDROID_AUTO the real T-Box session's AndroidAutoSessionService uses - the
+    // two never run at once (start() below refuses while AndroidAutoRuntime.isActive()), so
+    // there is only ever one MediaButtonBridge registered under that name. Without this,
+    // "Buttons control Android Auto" / the handlebar mapping wizard had nothing to capture at
+    // all while testing phone-only (field report 2026-08-13: HID presses did nothing here, not
+    // even the leftover-open-VolumeProvider bug affecting the T-Box path — there was no bridge
+    // to receive them in the first place).
+    private var mediaButtonBridge: MediaButtonBridge? = null
     private var selfModeJob: Job? = null
     private var videoWidth = 0
     private var videoHeight = 0
@@ -96,11 +106,26 @@ class PhoneOnlyAndroidAutoBridge(private val context: Context) :
         // callback while compositor is still null and leave the phone preview blank forever.
         AndroidAutoPreviewRuntime.install(this)
 
+        if (mediaButtonBridge == null) {
+            mediaButtonBridge = MediaButtonBridge(
+                context = context,
+                log = { ProjectionEventLog.debug("PHONE_ONLY_AA", it) },
+                targetName = MediaButtonBridge.TARGET_ANDROID_AUTO
+            ).also { it.start() }
+        }
+
         val activeReceiver = AaReceiver(
             context = context,
             encoderSurface = decoderSurface,
             log = { ProjectionEventLog.debug("PHONE_ONLY_AA", it) },
-            onVideoReady = { AndroidAutoRuntime.publish(AndroidAutoRuntimeState.Streaming) },
+            onVideoReady = {
+                AndroidAutoRuntime.publish(AndroidAutoRuntimeState.Streaming)
+                // Same order as AndroidAutoSessionService.prepareEncoder(): capture only turns on
+                // once video is actually flowing, and the re-assert needs the transport up first.
+                val handlebarEnabled = HandlebarControlStore.isEnabled(context)
+                mediaButtonBridge?.setCaptureActive(handlebarEnabled)
+                if (handlebarEnabled) mediaButtonBridge?.reassertCaptureAfterTransportReady()
+            },
             onSessionEnded = { clean, userExit ->
                 AndroidAutoRuntime.publish(
                     AndroidAutoRuntimeState.Stopped(
@@ -204,6 +229,8 @@ class PhoneOnlyAndroidAutoBridge(private val context: Context) :
         compositor?.clearOutput()
         compositor?.release()
         compositor = null
+        mediaButtonBridge?.stop()
+        mediaButtonBridge = null
     }
 
     private companion object {

--- a/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarControlStore.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarControlStore.kt
@@ -19,6 +19,29 @@ enum class HandlebarAction(val id: String, val label: String) {
     NAV_3("nav3", "Navigate → place 3")
 }
 
+/**
+ * Which physical protocol the handlebar remote speaks.
+ *
+ * Real dashboards use AVRCP (default): ordinary Bluetooth media-key commands, read by
+ * [MediaButtonBridge] through a MediaSession. Some aftermarket handlebar remotes instead pair as
+ * a Bluetooth HID keyboard and send raw D-pad keycodes — those never reach a MediaSession no
+ * matter what has focus, so HID mode instead relies on [HandlebarHidCaptureService], an
+ * Accessibility Service, to see them system-wide.
+ */
+enum class HandlebarInputMode(val id: String, val label: String, val description: String) {
+    AVRCP(
+        "avrcp",
+        "AVRCP (media keys)",
+        "Default. The dashboard sends Bluetooth media-key commands for play/pause, track and volume."
+    ),
+    HID(
+        "hid",
+        "HID (D-pad)",
+        "For remotes that pair as a Bluetooth keyboard and send D-pad presses. Requires turning " +
+            "on MOTO-HUB's Accessibility Service below."
+    )
+}
+
 enum class HandlebarGesture(
     val id: String,
     val label: String,
@@ -41,7 +64,38 @@ enum class HandlebarGesture(
     TRACK_BACK_LONG("trackBackLong", "Backward hold - Left", "Requires a real Bluetooth key-up", HandlebarAction.NONE),
     TRACK_FORWARD("trackForward", "Forward - Right", "Bluetooth next-track command", HandlebarAction.SCROLL_FORWARD),
     TRACK_FORWARD_DOUBLE("trackForwardDouble", "Forward double tap - Right", "Two next-track presses inside the window", HandlebarAction.BACK),
-    TRACK_FORWARD_LONG("trackForwardLong", "Forward hold - Right", "Requires a real Bluetooth key-up", HandlebarAction.NONE)
+    TRACK_FORWARD_LONG("trackForwardLong", "Forward hold - Right", "Requires a real Bluetooth key-up", HandlebarAction.NONE);
+
+    /**
+     * The double-tap sibling of a base ("press") gesture in the same family, or null for a
+     * gesture that isn't a base press. Lets [HandlebarCalibrationScreen] confirm the rider
+     * actually double-tapped during a "double" teaching step, instead of accepting whatever
+     * gesture fires next regardless of shape (field report 2026-08-13: a single tap during the
+     * double/hold step silently overwrote the binding with the plain press).
+     */
+    fun doubleSibling(): HandlebarGesture? = when (this) {
+        VOLUME_UP -> VOLUME_UP_DOUBLE
+        VOLUME_DOWN -> VOLUME_DOWN_DOUBLE
+        ENTER -> ENTER_DOUBLE
+        TRACK_BACK -> TRACK_BACK_DOUBLE
+        TRACK_FORWARD -> TRACK_FORWARD_DOUBLE
+        else -> null
+    }
+
+    /**
+     * The hold sibling, or null when this family has no hold gesture at all. Volume never does:
+     * AVRCP's absolute-volume stream and a HID remote's discrete volume key both only ever
+     * produce a press or a double (see [io.motohub.android.feature.controls.MediaButtonBridge]'s
+     * interpretVolumeDelta/onHidVolumeKey) - there is nothing a "held" volume press could mean.
+     * The calibration wizard uses this to auto-skip a hold step instead of waiting forever for a
+     * gesture that can never arrive.
+     */
+    fun longSibling(): HandlebarGesture? = when (this) {
+        ENTER -> ENTER_LONG
+        TRACK_BACK -> TRACK_BACK_LONG
+        TRACK_FORWARD -> TRACK_FORWARD_LONG
+        else -> null
+    }
 }
 
 object HandlebarControlStore {
@@ -50,6 +104,7 @@ object HandlebarControlStore {
     private const val MANAGED_BY_COMPANION = "managed_by_companion"
     private const val DASHBOARD_REPORTS_HOLDS = "dashboard_reports_holds"
     private const val CALIBRATION_PREFIX = "calibrated_"
+    private const val INPUT_MODE = "input_mode"
     /** Bumped when [defaultAction] values change — auto-migrates stored overrides. */
     private const val DEFAULTS_VER = 2
     private const val KEY_DEFAULTS_VER = "defaults_ver"
@@ -65,6 +120,17 @@ object HandlebarControlStore {
 
     fun setEnabled(context: Context, enabled: Boolean) {
         MotorcycleScope.putBoolean(preferences(context), context, ENABLED, enabled)
+    }
+
+    /** Scoped per motorcycle, like [isEnabled]: a remote's protocol is a property of that bike's
+     *  handlebar hardware, not of the phone. */
+    fun inputMode(context: Context): HandlebarInputMode {
+        val stored = MotorcycleScope.getString(preferences(context), context, INPUT_MODE, null)
+        return HandlebarInputMode.entries.firstOrNull { it.id == stored } ?: HandlebarInputMode.AVRCP
+    }
+
+    fun setInputMode(context: Context, mode: HandlebarInputMode) {
+        MotorcycleScope.putString(preferences(context), context, INPUT_MODE, mode.id)
     }
 
     /**

--- a/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarHidCaptureService.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarHidCaptureService.kt
@@ -1,0 +1,100 @@
+package io.motohub.android.feature.controls
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.view.KeyEvent
+import android.view.accessibility.AccessibilityEvent
+import io.motohub.android.session.ProjectionEventLog
+
+/**
+ * Sees key presses from a Bluetooth HID-keyboard handlebar remote system-wide, regardless of
+ * which app currently has focus on the TFT.
+ *
+ * Ordinary HID key events are delivered only to whatever window has focus — during a ride that
+ * is normally Android Auto's own surface, not this app — so a plain `dispatchKeyEvent` in
+ * [io.motohub.android.MainActivity] would never see them. Worse, a literal volume keycode
+ * bypasses app focus entirely and goes straight to the system volume UI. An Accessibility
+ * Service with [AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS] is the one mechanism
+ * short of root that can intercept either before that happens, which is why HID mode exists
+ * as a whole: [MediaButtonBridge]'s normal path only ever sees keys the system already decided
+ * to treat as AVRCP media-button events.
+ *
+ * Entirely inert unless BOTH are true: the rider granted this service in system Accessibility
+ * settings (an explicit toggle Android requires; nothing in-app can flip it for them — see
+ * [openAccessibilitySettings]) AND [HandlebarControlStore.inputMode] is currently
+ * [HandlebarInputMode.HID]. In AVRCP mode, or with the service off, every key event is returned
+ * unconsumed so it reaches whatever app would normally get it.
+ */
+class HandlebarHidCaptureService : AccessibilityService() {
+
+    override fun onServiceConnected() {
+        serviceInfo = AccessibilityServiceInfo().apply {
+            eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+            feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+            flags = AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS
+            notificationTimeout = 0
+        }
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent) = Unit
+
+    override fun onInterrupt() = Unit
+
+    override fun onKeyEvent(event: KeyEvent): Boolean {
+        // Traced unconditionally, before every gate below: whether this even fires at all is
+        // the first fact needed to tell "Android never delivered the key event here" apart from
+        // "it arrived but a gate downstream dropped it" - the two look identical from a rider
+        // just seeing the press do nothing.
+        val actionName = when (event.action) {
+            KeyEvent.ACTION_DOWN -> "down"
+            KeyEvent.ACTION_UP -> "up"
+            else -> "action=${event.action}"
+        }
+        val trace = "[HID] raw ${KeyEvent.keyCodeToString(event.keyCode)} $actionName " +
+            "repeat=${event.repeatCount} source=${event.source}"
+        if (HandlebarControlStore.inputMode(applicationContext) != HandlebarInputMode.HID) {
+            ProjectionEventLog.debug("HID_BTN", "$trace (AVRCP mode selected; ignored)")
+            return false
+        }
+        if (!HandlebarControlStore.isEnabled(applicationContext)) {
+            ProjectionEventLog.record("HID_BTN", "$trace (handlebar capture is off in Settings; ignored)")
+            return false
+        }
+        val consumed = MediaButtonBridge.dispatchHidKeyEvent(event.keyCode, event.action, event.repeatCount)
+        if (!consumed) {
+            ProjectionEventLog.record(
+                "HID_BTN",
+                "$trace not consumed - no session is capturing right now (start Android Auto " +
+                    "or mirroring first), or this keycode is not recognized"
+            )
+        }
+        return consumed
+    }
+
+    companion object {
+        /** Deep-links to the system screen where the rider grants this service — Android
+         *  requires an explicit in-settings toggle; no runtime permission covers it. */
+        fun openAccessibilitySettings(context: Context) {
+            runCatching {
+                context.startActivity(
+                    Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }
+        }
+
+        /** Whether the rider has already granted this service, for the settings screen's hint. */
+        fun isEnabled(context: Context): Boolean {
+            val expected = ComponentName(context, HandlebarHidCaptureService::class.java).flattenToString()
+            val enabled = Settings.Secure.getString(
+                context.contentResolver,
+                Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+            ) ?: return false
+            return enabled.split(':').any { it.equals(expected, ignoreCase = true) }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarMappingScreen.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarMappingScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -43,7 +45,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.motohub.android.androidauto.AndroidAutoRuntime
+import io.motohub.android.androidauto.AndroidAutoRuntimeState
+import io.motohub.android.data.MotorcycleProfileStore
 import io.motohub.android.i18n.motoHubText
+import io.motohub.android.session.MotorcycleProfile
 import io.motohub.android.session.ProjectionEventLog
 import io.motohub.android.ui.components.MonoLabel
 import io.motohub.android.ui.components.MotoHubDetailScreen
@@ -73,6 +80,22 @@ fun HandlebarMappingScreen(
     var revision by remember { mutableStateOf(0) }
     var editing by remember { mutableStateOf<PhysicalPress?>(null) }
     var calibrating by remember { mutableStateOf(false) }
+    var showTeachPrerequisiteDialog by remember { mutableStateOf(false) }
+    // Set when the prerequisite dialog asked MainActivity to start a session, so the rider
+    // doesn't have to notice it came up and tap "Teach my handlebar" a second time - the whole
+    // point of asking was to get straight into teaching once there is something to capture.
+    var awaitingSessionForTeach by remember { mutableStateOf(false) }
+    val androidAutoState by AndroidAutoRuntime.state.collectAsState()
+    LaunchedEffect(androidAutoState, awaitingSessionForTeach) {
+        if (!awaitingSessionForTeach) return@LaunchedEffect
+        // Streaming specifically, not just Preparing/ReceiverReady: MediaButtonBridge only
+        // flips captureActive once video is actually flowing (see onVideoReady), so opening the
+        // wizard any earlier would just look broken - presses would register nothing yet.
+        if (androidAutoState is AndroidAutoRuntimeState.Streaming) {
+            awaitingSessionForTeach = false
+            calibrating = true
+        }
+    }
     val lastGesture by HandlebarGestureFeed.lastGesture.collectAsState()
     var litGesture by remember { mutableStateOf<HandlebarGesture?>(null) }
     LaunchedEffect(lastGesture?.atElapsedRealtimeMillis) {
@@ -144,7 +167,21 @@ fun HandlebarMappingScreen(
         LiveCaptureBanner(litGesture)
 
         Button(
-            onClick = { calibrating = true },
+            onClick = {
+                // Calibration only ever sees anything through a live capture (MediaButtonBridge
+                // captureActive) - with no Android Auto session at all there is nothing to
+                // teach from, and the wizard would just sit there looking broken. Checked here
+                // rather than inside the wizard so the rider is asked before it opens, not left
+                // to guess why nothing on the motorcycle does anything once it has.
+                val sessionRunning = androidAutoState is AndroidAutoRuntimeState.Streaming ||
+                    androidAutoState is AndroidAutoRuntimeState.ReceiverReady ||
+                    androidAutoState is AndroidAutoRuntimeState.Preparing
+                if (sessionRunning) {
+                    calibrating = true
+                } else {
+                    showTeachPrerequisiteDialog = true
+                }
+            },
             modifier = Modifier.fillMaxWidth().height(52.dp),
             shape = RoundedCornerShape(16.dp)
         ) {
@@ -153,6 +190,32 @@ fun HandlebarMappingScreen(
                     if (HandlebarCalibration.isCalibrated(context)) "Teach again" else "Teach my handlebar"
                 ),
                 fontWeight = FontWeight.Bold
+            )
+        }
+        if (showTeachPrerequisiteDialog) {
+            HandlebarTeachPrerequisiteDialog(
+                motorcycles = remember { MotorcycleProfileStore(context).loadAll() },
+                onConnect = { profile ->
+                    ProjectionEventLog.record(
+                        "CONTROLS",
+                        "Handlebar teach requested a connect to ${profile.ssid} to get a live session."
+                    )
+                    HandlebarTeachPrerequisiteRequest.publish(
+                        HandlebarTeachPrerequisiteRequest.Choice.Connect(profile.id)
+                    )
+                    awaitingSessionForTeach = true
+                    showTeachPrerequisiteDialog = false
+                },
+                onPhoneOnly = {
+                    ProjectionEventLog.record(
+                        "CONTROLS",
+                        "Handlebar teach requested a phone-only Android Auto session."
+                    )
+                    HandlebarTeachPrerequisiteRequest.publish(HandlebarTeachPrerequisiteRequest.Choice.PhoneOnly)
+                    awaitingSessionForTeach = true
+                    showTeachPrerequisiteDialog = false
+                },
+                onDismiss = { showTeachPrerequisiteDialog = false }
             )
         }
 
@@ -175,6 +238,69 @@ fun HandlebarMappingScreen(
             },
             modifier = Modifier.fillMaxWidth()
         ) { Text(motoHubText("Reset actions to defaults")) }
+    }
+}
+
+/**
+ * Asked before opening the teach wizard when no Android Auto session is running - see the
+ * "Teach my handlebar" button above. Offers exactly the two ways this app can get a live
+ * session: connect to a saved motorcycle's T-Box (with a choice of which, if more than one is
+ * saved), or start Android Auto entirely on the phone with no T-Box at all. Neither is done
+ * here directly - this screen has no session-state or permission-launcher access of its own,
+ * so the choice is published for MainActivity to act on (see [HandlebarTeachPrerequisiteRequest]).
+ */
+@Composable
+private fun HandlebarTeachPrerequisiteDialog(
+    motorcycles: List<MotorcycleProfile>,
+    onConnect: (MotorcycleProfile) -> Unit,
+    onPhoneOnly: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = RoundedCornerShape(20.dp), color = MaterialTheme.colorScheme.surface) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                Text(
+                    motoHubText("Android Auto isn't running"),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    motoHubText(
+                        "Teaching the handlebar needs a live Android Auto session to capture " +
+                            "presses. Connect to the motorcycle, or start it on this phone " +
+                            "without a T-Box."
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (motorcycles.isNotEmpty()) {
+                    HorizontalDivider()
+                    motorcycles.forEach { profile ->
+                        OutlinedButton(
+                            onClick = { onConnect(profile) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                motoHubText(
+                                    "Connect to %1\$s",
+                                    profile.displayName?.takeIf(String::isNotBlank) ?: profile.ssid
+                                )
+                            )
+                        }
+                    }
+                }
+                HorizontalDivider()
+                Button(onClick = onPhoneOnly, modifier = Modifier.fillMaxWidth()) {
+                    Text(motoHubText("Start on this phone (no T-Box)"), fontWeight = FontWeight.Bold)
+                }
+                TextButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                    Text(motoHubText("Cancel"))
+                }
+            }
+        }
     }
 }
 
@@ -205,13 +331,21 @@ private fun BluetoothStatusCard() {
         ActivityResultContracts.RequestPermission()
     ) { refresh++ }
     val current = status
+    // A2DP/HEADSET "connected device" only means something for an AVRCP dash - a HID remote
+    // pairs as a keyboard and never shows up in that list, so current.describe() would call an
+    // actually-working HID remote "no audio device connected" (field report 2026-08-13). HID
+    // mode has no per-device connection signal to show at all here; "ready" is the same
+    // Bluetooth-on-and-permitted check that actually gates capture (see
+    // BluetoothStatus.canReceiveHandlebarKeys).
+    val hidMode = HandlebarControlStore.inputMode(context) == HandlebarInputMode.HID
     val connected = current?.connected == true
+    val ready = if (hidMode) current?.enabled == true && current.permitted else connected
     val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
         current?.permitted == false
 
     Surface(
         shape = RoundedCornerShape(16.dp),
-        color = if (connected) {
+        color = if (ready) {
             MotoHubLive.copy(alpha = 0.12f)
         } else {
             MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
@@ -228,7 +362,7 @@ private fun BluetoothStatusCard() {
             ) {
                 Box(
                     Modifier.size(10.dp).background(
-                        if (connected) MotoHubLive
+                        if (ready) MotoHubLive
                         else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
                         CircleShape
                     )
@@ -240,7 +374,20 @@ private fun BluetoothStatusCard() {
                 )
             }
             Text(
-                current?.describe() ?: motoHubText("Checking Bluetooth…"),
+                when {
+                    current == null -> motoHubText("Checking Bluetooth…")
+                    !hidMode -> current.describe()
+                    !current.supported -> motoHubText("This phone has no Bluetooth.")
+                    !current.enabled -> motoHubText("Bluetooth is off — turn it on, then pair the remote as a keyboard.")
+                    !current.permitted -> motoHubText(
+                        "Allow Bluetooth access so the app can read the remote's key presses."
+                    )
+                    else -> motoHubText(
+                        "Bluetooth is on. A HID remote doesn't show up here as a connected " +
+                            "device — if presses still aren't recognized, check it is paired " +
+                            "in system Bluetooth settings and that Accessibility is turned on."
+                    )
+                },
                 style = MaterialTheme.typography.bodyMedium
             )
             if (current != null && current.supported) {
@@ -388,7 +535,48 @@ private fun HandlebarCalibrationScreen(onDone: () -> Unit) {
     // before the screen even opened, which is how a stale feed value once got recorded as
     // "up_press = trackBack" with the rider's hand nowhere near the handlebar.
     var stepStartedAt by remember { mutableStateOf(SystemClock.elapsedRealtime()) }
-    LaunchedEffect(step) { stepStartedAt = SystemClock.elapsedRealtime() }
+    // Feedback for a gesture that arrived but didn't match what this step needs - shown instead
+    // of silently accepting it (see the LaunchedEffect below) or silently ignoring it.
+    var mismatchHint by remember { mutableStateOf<String?>(null) }
+    // Feedback for a step that is skipped automatically because it can never be satisfied (a
+    // volume-mapped button has no hold gesture at all) - shown instead of silently advancing
+    // past it with nothing on screen to explain why (field report 2026-08-13).
+    var skipNotice by remember { mutableStateOf<String?>(null) }
+
+    /** The gesture recorded for this button's PRESS step, taught earlier in the fixed
+     *  press/double/hold order - tells us which family (and so which double/hold siblings, if
+     *  any) this physical button belongs to. */
+    fun baseGestureFor(current: PhysicalPress): HandlebarGesture? = PhysicalPress.entries
+        .firstOrNull { it.button == current.button && it.kind == PressKind.PRESS }
+        ?.let { HandlebarCalibration.gestureFor(context, it) }
+
+    LaunchedEffect(step) {
+        stepStartedAt = SystemClock.elapsedRealtime()
+        mismatchHint = null
+        skipNotice = null
+        val current = press ?: return@LaunchedEffect
+        if (current.kind == PressKind.PRESS) return@LaunchedEffect
+        val baseGesture = baseGestureFor(current)
+        val expected = if (current.kind == PressKind.DOUBLE) {
+            baseGesture?.doubleSibling()
+        } else {
+            baseGesture?.longSibling()
+        }
+        if (baseGesture != null && expected == null) {
+            // Known upfront, before any press arrives: this button's family has no hold gesture
+            // at all (volume never does - see HandlebarGesture.longSibling). Waiting for one
+            // would hang forever, so this is announced and skipped immediately instead of
+            // silently advancing past it on the next unrelated press.
+            skipNotice = "This button has no hold - skipping automatically."
+            ProjectionEventLog.record(
+                "CONTROLS",
+                "Skipped ${current.id}: ${baseGesture.id} has no hold sibling."
+            )
+            learned++
+            delay(SKIP_NOTICE_MILLIS)
+            step++
+        }
+    }
 
     // Gestures are observed, not obeyed, for as long as this screen is up.
     DisposableEffect(Unit) {
@@ -400,6 +588,32 @@ private fun HandlebarCalibrationScreen(onDone: () -> Unit) {
         val event = lastGesture ?: return@LaunchedEffect
         val current = press ?: return@LaunchedEffect
         if (event.atElapsedRealtimeMillis <= stepStartedAt) return@LaunchedEffect
+        // The no-hold-exists case is announced and skipped by the step-change effect above,
+        // before any press arrives - this only validates the shape of an actual incoming gesture.
+        if (skipNotice != null) return@LaunchedEffect
+
+        // The "press" step for this same physical button was always taught first (PhysicalPress
+        // orders press/double/hold together per button) - its recorded gesture is this button's
+        // family, and tells us which gesture id actually PROVES a double or a hold happened,
+        // rather than accepting whatever fires next (field report 2026-08-13: a single tap
+        // during the double/hold step silently overwrote both with the plain press).
+        val baseGesture = baseGestureFor(current)
+        val expected = when (current.kind) {
+            PressKind.PRESS -> null
+            PressKind.DOUBLE -> baseGesture?.doubleSibling()
+            PressKind.HOLD -> baseGesture?.longSibling()
+        }
+
+        if (expected != null && event.gesture != expected) {
+            mismatchHint = when (current.kind) {
+                PressKind.DOUBLE -> "That was a single press - press twice quickly for double."
+                PressKind.HOLD -> "That was a quick tap - press and hold a moment longer."
+                PressKind.PRESS -> null
+            }
+            return@LaunchedEffect
+        }
+
+        mismatchHint = null
         HandlebarCalibration.record(context, current, event.gesture)
         ProjectionEventLog.record("CONTROLS", "Calibrated ${current.id} = ${event.gesture.id}")
         learned++
@@ -452,6 +666,22 @@ private fun HandlebarCalibrationScreen(onDone: () -> Unit) {
                     fontWeight = FontWeight.Bold
                 )
             }
+        }
+        mismatchHint?.let { hint ->
+            Text(
+                motoHubText(hint),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+        skipNotice?.let { notice ->
+            Text(
+                motoHubText(notice),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.error
+            )
         }
         Text(
             motoHubText(
@@ -757,3 +987,6 @@ private fun HandlebarAction.shortLabel(): String = when (this) {
 
 private const val HIGHLIGHT_MILLIS = 1_400L
 private const val CALIBRATION_CONFIRM_MILLIS = 700L
+/** Longer than CALIBRATION_CONFIRM_MILLIS - this is an unrequested notice about a step the
+ *  rider never got a chance to act on, not a confirmation of something they just did. */
+private const val SKIP_NOTICE_MILLIS = 1800L

--- a/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarTeachPrerequisiteRequest.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/controls/HandlebarTeachPrerequisiteRequest.kt
@@ -1,0 +1,32 @@
+package io.motohub.android.feature.controls
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * One-shot signal from the "Teach my handlebar" prerequisite dialog (see
+ * [HandlebarMappingScreen]) asking Core's MainActivity to get an Android Auto session running.
+ * Calibration needs live capture ([io.motohub.android.feature.controls.MediaButtonBridge]'s
+ * `captureActive`) to see anything at all, and this dialog is reached from deep inside
+ * Settings, with no session-state or permission-launcher access of its own to start one
+ * directly - mirrors [io.motohub.android.androidauto.PhoneOnlyAndroidAutoLaunchRequest]'s shape
+ * for the same reason.
+ */
+object HandlebarTeachPrerequisiteRequest {
+    sealed interface Choice {
+        /** Start Android Auto entirely on this phone, no T-Box - see
+         *  [io.motohub.android.androidauto.PhoneOnlyAndroidAutoBridge]. */
+        data object PhoneOnly : Choice
+
+        /** Select this saved motorcycle as active, then connect to its T-Box. */
+        data class Connect(val motorcycleId: String) : Choice
+    }
+
+    private val mutableRequests = MutableSharedFlow<Choice>(extraBufferCapacity = 1)
+    val requests: SharedFlow<Choice> = mutableRequests.asSharedFlow()
+
+    fun publish(choice: Choice) {
+        mutableRequests.tryEmit(choice)
+    }
+}

--- a/apps/android/app/src/main/java/io/motohub/android/feature/controls/MediaButtonBridge.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/controls/MediaButtonBridge.kt
@@ -313,6 +313,14 @@ class MediaButtonBridge(
      * missed gesture is worse than a held volume.
      */
     private fun volumeGesturesInUse(): Boolean {
+        // HID mode gets real, discrete KEYCODE_VOLUME_UP/DOWN key-down events from
+        // HandlebarHidCaptureService (see onHidKeyEvent) - there is nothing to infer from
+        // watching the media stream drift, and pinning it here would fight the Accessibility
+        // Service for ownership of the same physical press: a rider's "up" button would both
+        // navigate AND visibly move the pinned volume, or worse, the pin's own re-write could
+        // be misread as a second press. AVRCP's pin-and-watch trick is only needed because
+        // AVRCP volume changes never arrive as ordinary key events in the first place.
+        if (HandlebarControlStore.inputMode(context) == HandlebarInputMode.HID) return false
         // An uncalibrated handlebar assumes a rocker, which is right for most dashboards and
         // wrong forever for the ones that never send one. The silence probe settles it without
         // asking the rider (see [scheduleVolumeSilenceProbe]).
@@ -339,7 +347,16 @@ class MediaButtonBridge(
         //
         // Not a check on whether the motorcycle is connected. A dash that is off or out of range
         // will turn up during the ride, and refusing to listen for it would be the worse mistake.
-        if (!BluetoothStatus.canReceiveHandlebarKeys(context)) {
+        //
+        // HID mode is exempt: canReceiveHandlebarKeys() checks BLUETOOTH_CONNECT, which this app
+        // needs to ask the Bluetooth stack "is anything connected" for the AVRCP path - but a HID
+        // remote's key events arrive as ordinary input through HandlebarHidCaptureService's
+        // Accessibility Service, which needs no Bluetooth permission of its own to see them.
+        // Field report 2026-08-13: capture stayed permanently skipped on a phone that had never
+        // granted BLUETOOTH_CONNECT, even though the HID remote's presses were already reaching
+        // the Accessibility Service and being dropped downstream for exactly this reason.
+        val hidMode = HandlebarControlStore.inputMode(context) == HandlebarInputMode.HID
+        if (!hidMode && !BluetoothStatus.canReceiveHandlebarKeys(context)) {
             log(
                 "[BTN] capture skipped: Bluetooth is off or unavailable to this app, so no " +
                     "handlebar press can arrive - leaving the media volume and audio focus alone"
@@ -366,6 +383,14 @@ class MediaButtonBridge(
         } else {
             log("[BTN] volume keys are not delivered by this dashboard; leaving the media volume alone")
         }
+        // installRemoteVolume() matters even more in HID mode than in AVRCP: field trace
+        // 2026-08-13 showed KEYCODE_VOLUME_UP/DOWN from a HID remote never reaching
+        // HandlebarHidCaptureService at all - MediaSessionService's dispatchVolumeKeyEvent
+        // claimed them first and routed them to Android Auto's OWN app (gearhead), which was
+        // holding the relevant session. A VolumeProvider is what lets THIS app win that routing
+        // instead (see onAdjustVolume below); without one, whichever app the system picks gets
+        // the press and this bridge never sees a KeyEvent to filter in the first place. See
+        // onHidVolumeKey for how HID mode's callback differs from AVRCP's (onPhoneVolumeKey).
         installRemoteVolume()
         val granted = requestMediaFocus()
         startSilentTrack()
@@ -505,6 +530,15 @@ class MediaButtonBridge(
                 if (!captureActive) return@postDelayed
                 runCatching {
                     refreshPlayingAppearance(reason = "reclaim")
+                    // A full AUDIOFOCUS_LOSS (not just a duck) means something else - Android
+                    // Auto's own audio/call activity, observed field-side 2026-08-13 - may have
+                    // become the system's volume-key routing target while it held focus.
+                    // refreshPlayingAppearance only re-asserts the MediaSession's playing state;
+                    // it does not re-attach the VolumeProvider, so without this call hardware
+                    // volume presses kept moving the phone's REAL media volume for the next
+                    // 15+ seconds after "handlebar reclaimed" already logged - the session was
+                    // reclaimed, but volume-key ownership specifically was not.
+                    installRemoteVolume()
                     if (usesVolumeGestures) pinVolume()
                     // The pin above just reasserted the reference level (under its own ignore
                     // window), so volume moves are readable as gestures again.
@@ -595,7 +629,18 @@ class MediaButtonBridge(
         val provider = object : VolumeProvider(VOLUME_CONTROL_ABSOLUTE, max, current) {
             override fun onAdjustVolume(direction: Int) {
                 if (direction == 0) return
-                handler.post { onPhoneVolumeKey(direction) }
+                handler.post {
+                    // AVRCP: this is how the PHONE's own hardware volume keys are told apart
+                    // from the dash's absolute-volume writes (see the class doc above). HID:
+                    // there is no separate "dash" signal to protect - a HID remote's volume
+                    // button IS one of these discrete key events, indistinguishable from the
+                    // phone's own buttons, so THIS is the handlebar press (see onHidVolumeKey).
+                    if (HandlebarControlStore.inputMode(context) == HandlebarInputMode.HID) {
+                        onHidVolumeKey(direction)
+                    } else {
+                        onPhoneVolumeKey(direction)
+                    }
+                }
             }
 
             override fun onSetVolumeTo(volume: Int) {
@@ -609,6 +654,23 @@ class MediaButtonBridge(
         } catch (failure: Throwable) {
             log("[BTN] remote volume install failed (${failure.message}); phone volume keys may still register as presses")
         }
+    }
+
+    /**
+     * One HID remote volume press, delivered via [installRemoteVolume]'s VolumeProvider instead
+     * of [HandlebarHidCaptureService]'s Accessibility Service - on at least one real device
+     * (Pixel 8, field trace 2026-08-13) MediaSessionService's dispatchVolumeKeyEvent claimed the
+     * raw KeyEvent for Android Auto's own app before the Accessibility Service ever saw it, so
+     * this is the path that actually fires for volume in practice. A genuine discrete key press
+     * with a direction, not an absolute value to infer a gesture from - reuses the same
+     * tap/double-tap detection [onKeyDown] gives an AVRCP dash's literal key press.
+     */
+    private fun onHidVolumeKey(direction: Int) {
+        if (!captureActive) return
+        val single = if (direction > 0) HandlebarGesture.VOLUME_UP else HandlebarGesture.VOLUME_DOWN
+        val double = if (direction > 0) HandlebarGesture.VOLUME_UP_DOUBLE else HandlebarGesture.VOLUME_DOWN_DOUBLE
+        log("[BTN] HID volume ${if (direction > 0) "up" else "down"} (via VolumeProvider) -> $targetName")
+        detectDoubleTap(single, double, forceDouble = false)
     }
 
     /** One phone volume-key press: step the real listening volume, same stride the OS would use. */
@@ -853,6 +915,54 @@ class MediaButtonBridge(
         }
     }
 
+    /**
+     * Feeds one raw key event captured system-wide by [HandlebarHidCaptureService] (HID mode
+     * only). Two shapes of HID remote are supported:
+     *
+     * - Volume/select/track keycodes ([isVolumeKey]/[isSelectKey]/[isTrackKey]) — the common
+     *   case for a remote whose five buttons mirror AVRCP's (up/down/play/back/forward), just
+     *   delivered as ordinary HID keys instead of over a MediaSession. These route through the
+     *   SAME [onKeyDown]/[onKeyUp] tap/hold/double-tap machinery AVRCP uses, so
+     *   [HandlebarControlStore]'s calibration and the mapping screen apply identically regardless
+     *   of which transport the press arrived over — a HID remote's "up" button IS
+     *   [HandlebarGesture.VOLUME_UP], the same gesture id an AVRCP dash's volume rocker produces.
+     * - D-pad arrow keycodes — for remotes wired as a literal 4-way pad instead. Fixed mapping,
+     *   not run through the calibration wizard: there is no "up press" left to teach when the
+     *   remote already reports which direction was pressed.
+     *
+     * Anything else is logged and left unconsumed, so a rider hitting an unrecognized button can
+     * find the keycode in the diagnostic log and report it instead of the button silently doing
+     * nothing.
+     */
+    fun onHidKeyEvent(keyCode: Int, action: Int, repeatCount: Int): Boolean {
+        if (!captureActive) return false
+        dpadKeyTarget(keyCode)?.let { target ->
+            if (action == KeyEvent.ACTION_DOWN && repeatCount == 0) {
+                log("[BTN] HID D-pad ${KeyEvent.keyCodeToString(keyCode)} -> $targetName")
+                sendKey(target)
+            }
+            return true
+        }
+        if (!isVolumeKey(keyCode) && !isSelectKey(keyCode) && !isTrackKey(keyCode)) {
+            log("[BTN] HID key ${KeyEvent.keyCodeToString(keyCode)} ($keyCode) not recognized; ignored")
+            return false
+        }
+        when (action) {
+            KeyEvent.ACTION_DOWN -> onKeyDown(keyCode, repeatCount)
+            KeyEvent.ACTION_UP -> onKeyUp(keyCode)
+        }
+        return true
+    }
+
+    private fun dpadKeyTarget(keyCode: Int): Int? = when (keyCode) {
+        KeyEvent.KEYCODE_DPAD_UP -> AndroidAutoInputCodes.KEY_UP
+        KeyEvent.KEYCODE_DPAD_DOWN -> AndroidAutoInputCodes.KEY_DOWN
+        KeyEvent.KEYCODE_DPAD_LEFT -> AndroidAutoInputCodes.KEY_LEFT
+        KeyEvent.KEYCODE_DPAD_RIGHT -> AndroidAutoInputCodes.KEY_RIGHT
+        KeyEvent.KEYCODE_DPAD_CENTER -> AndroidAutoInputCodes.KEY_ENTER
+        else -> null
+    }
+
     fun injectSimulatorGesture(gesture: HandlebarGesture) {
         handler.post {
             log("[BTN] simulator injected ${gesture.label}")
@@ -934,7 +1044,18 @@ class MediaButtonBridge(
 
     private fun isSelectKey(keyCode: Int) = keyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
         keyCode == KeyEvent.KEYCODE_MEDIA_PAUSE ||
-        keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
+        keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE ||
+        // HID-only aliases: a remote's "call/select" button commonly reports as one of these
+        // instead of a MEDIA_PLAY* keycode. Harmless to recognize on the AVRCP path too - no
+        // Bluetooth AVRCP peer has ever been observed sending either through onMediaButtonEvent.
+        keyCode == KeyEvent.KEYCODE_HEADSETHOOK ||
+        keyCode == KeyEvent.KEYCODE_ENTER
+
+    /** HID-only: a literal volume keycode, delivered as a discrete press with a real key-up -
+     *  unlike AVRCP's absolute-volume writes, there is nothing to infer here (see
+     *  [volumeGesturesInUse]), so this is handled entirely in [onKeyDown]/[onKeyUp]. */
+    private fun isVolumeKey(keyCode: Int) =
+        keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
 
     private fun onKeyDown(keyCode: Int, repeatCount: Int = 0) {
         lastKeyAt = SystemClock.elapsedRealtime()
@@ -943,6 +1064,20 @@ class MediaButtonBridge(
             return
         }
         log("[BTN] media key ${KeyEvent.keyCodeToString(keyCode)} down ($keyCode)")
+        if (isVolumeKey(keyCode)) {
+            val single = if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+                HandlebarGesture.VOLUME_UP
+            } else {
+                HandlebarGesture.VOLUME_DOWN
+            }
+            val double = if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+                HandlebarGesture.VOLUME_UP_DOUBLE
+            } else {
+                HandlebarGesture.VOLUME_DOWN_DOUBLE
+            }
+            detectDoubleTap(single, double, forceDouble = false)
+            return
+        }
         when {
             isSelectKey(keyCode) -> if (selectDownAt == 0L) {
                 selectDownAt = SystemClock.elapsedRealtime()
@@ -1224,6 +1359,12 @@ class MediaButtonBridge(
             bridge.injectSimulatorGesture(gesture)
             return true
         }
+
+        /** Routes one HID key event to whichever live bridge is capturing (see
+         *  [HandlebarHidCaptureService]). Returns true once any bridge claims the keycode, so
+         *  the Accessibility Service can consume it and stop it reaching the focused app. */
+        fun dispatchHidKeyEvent(keyCode: Int, action: Int, repeatCount: Int): Boolean =
+            bridges.values.any { it.onHidKeyEvent(keyCode, action, repeatCount) }
 
         /** Calibration changed — every live bridge re-decides whether to hold the volume pin. */
         fun refreshVolumeGestureUse() {

--- a/apps/android/app/src/main/java/io/motohub/android/feature/home/HubHomeScreen.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/home/HubHomeScreen.kt
@@ -103,6 +103,7 @@ fun HubHomeScreen(
     onStartAndroidAuto: () -> Unit,
     onStopAndroidAuto: () -> Unit,
     onOpenAndroidAutoPreview: () -> Unit,
+    onStartPhoneOnlyAndroidAuto: () -> Unit,
     dimDisplayEnabled: Boolean,
     onDimDisplayChanged: (Boolean) -> Unit,
     onStopProjection: () -> Unit,
@@ -161,6 +162,7 @@ fun HubHomeScreen(
                             onStartAndroidAuto = onStartAndroidAuto,
                             onStopAndroidAuto = onStopAndroidAuto,
                             onOpenAndroidAutoPreview = onOpenAndroidAutoPreview,
+                            onStartPhoneOnlyAndroidAuto = onStartPhoneOnlyAndroidAuto,
                             dimDisplayEnabled = dimDisplayEnabled,
                             onDimDisplayChanged = onDimDisplayChanged,
                             onStopProjection = onStopProjection,
@@ -208,6 +210,7 @@ private fun HomeTabContent(
     onStartAndroidAuto: () -> Unit,
     onStopAndroidAuto: () -> Unit,
     onOpenAndroidAutoPreview: () -> Unit,
+    onStartPhoneOnlyAndroidAuto: () -> Unit,
     dimDisplayEnabled: Boolean,
     onDimDisplayChanged: (Boolean) -> Unit,
     onStopProjection: () -> Unit,
@@ -287,7 +290,8 @@ private fun HomeTabContent(
                 onOpenAndroidAutoSettings = onOpenAndroidAutoSettings,
                 onScanQr = onScanQr,
                 onImportQrPhoto = onImportQrPhoto,
-                onManualPairing = onManualPairing
+                onManualPairing = onManualPairing,
+                onStartPhoneOnlyAndroidAuto = onStartPhoneOnlyAndroidAuto
             )
         }
         Spacer(Modifier.height(10.dp))
@@ -422,7 +426,8 @@ private fun ConnectionContent(
     onOpenAndroidAutoSettings: () -> Unit,
     onScanQr: () -> Unit,
     onImportQrPhoto: () -> Unit,
-    onManualPairing: () -> Unit
+    onManualPairing: () -> Unit,
+    onStartPhoneOnlyAndroidAuto: () -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
         errorMessage?.let { message ->
@@ -449,6 +454,13 @@ private fun ConnectionContent(
             SecondaryAction("Import QR", onImportQrPhoto, modifier = Modifier.weight(1f))
         }
         LinkRow("No QR? Connect manually", onManualPairing)
+        HorizontalDivider()
+        // Runs Android Auto entirely on the phone's own screen via
+        // PhoneOnlyAndroidAutoBridge - no T-Box, no Bluetooth, no motorcycle required. Exists
+        // for testing the Android Auto path itself (identity, handlebar mapping, ...) without
+        // a bike to hand; Advanced offers the same shortcut from its own home screen.
+        MonoLabel(motoHubText("OR RIGHT NOW, WITHOUT THE T-BOX"))
+        SecondaryAction(motoHubText("Android Auto — straight to your phone"), onStartPhoneOnlyAndroidAuto)
     }
 }
 

--- a/apps/android/app/src/main/java/io/motohub/android/feature/settings/SettingsScreen.kt
+++ b/apps/android/app/src/main/java/io/motohub/android/feature/settings/SettingsScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.dp
 import io.motohub.android.BuildConfig
 import io.motohub.android.R
 import io.motohub.android.feature.controls.HandlebarControlStore
+import io.motohub.android.feature.controls.HandlebarHidCaptureService
+import io.motohub.android.feature.controls.HandlebarInputMode
 import io.motohub.android.feature.controls.HandlebarMappingScreen
 import io.motohub.android.feature.controls.MediaButtonBridge
 import io.motohub.android.session.ProjectionEventLog
@@ -549,6 +551,7 @@ private fun DiagnosticsDetail(
 private fun HandlebarControlsDetail(onBack: () -> Unit, onOpenMapping: () -> Unit) {
     val context = LocalContext.current
     var enabled by remember { mutableStateOf(HandlebarControlStore.isEnabled(context)) }
+    var inputMode by remember { mutableStateOf(HandlebarControlStore.inputMode(context)) }
     val volumeLevels = remember { MediaButtonBridge.volumeLevels(context) }
     var listeningVolume by remember { mutableStateOf(volumeLevels.first.toFloat()) }
     MotoHubDetailScreen(
@@ -579,6 +582,51 @@ private fun HandlebarControlsDetail(onBack: () -> Unit, onOpenMapping: () -> Uni
                 color = MaterialTheme.colorScheme.error
             )
         }
+        MonoLabel(motoHubText("INPUT PROTOCOL"))
+        Text(
+            motoHubText(
+                "Most dashboards send buttons as AVRCP media keys — leave this on AVRCP. Pick " +
+                    "HID only if the remote pairs as a Bluetooth keyboard and its presses never " +
+                    "register below."
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        HandlebarInputMode.entries.forEach { candidate ->
+            MotoHubRadioRow(
+                title = motoHubText(candidate.label),
+                description = motoHubText(candidate.description),
+                selected = inputMode == candidate,
+                onClick = {
+                    inputMode = candidate
+                    HandlebarControlStore.setInputMode(context, candidate)
+                    ProjectionEventLog.record(
+                        "SETTINGS",
+                        "Handlebar input mode changed to ${candidate.name}."
+                    )
+                }
+            )
+        }
+        if (inputMode == HandlebarInputMode.HID) {
+            if (!HandlebarHidCaptureService.isEnabled(context)) {
+                Text(
+                    motoHubText(
+                        "HID mode also needs MOTO-HUB's Accessibility Service turned on, or " +
+                            "presses will not be seen."
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            MotoHubActionRow(
+                title = motoHubText("Open Accessibility settings"),
+                description = motoHubText(
+                    "Turn on MOTO-HUB so handlebar presses reach the app from any screen"
+                ),
+                onClick = { HandlebarHidCaptureService.openAccessibilitySettings(context) }
+            )
+        }
+        HorizontalDivider()
         ToggleRow(
             title = motoHubText("Buttons control Android Auto"),
             description = motoHubText(

--- a/apps/android/app/src/main/res/xml/handlebar_hid_capture_service.xml
+++ b/apps/android/app/src/main/res/xml/handlebar_hid_capture_service.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:canRequestFilterKeyEvents="true"
+    android:notificationTimeout="0"
+    android:description="@string/handlebar_hid_capture_description" />

--- a/translations/strings-en-US.xml
+++ b/translations/strings-en-US.xml
@@ -1274,4 +1274,9 @@
     <string name="legacy_several_manufacturers_ship_the_same_dashboard_so_49305d38">Several manufacturers ship the same dashboard software under their own branding, so this may well be your motorcycle. Continue only if you scanned it from your own dashboard.</string>
     <!-- Source: feature/pairing/UnverifiedQrDialog.kt -->
     <string name="legacy_use_these_details_52f852ac">Use these details</string>
+
+    <!-- Source: feature/controls/HandlebarHidCaptureService.kt (system Accessibility settings
+         description; rendered outside the app's own Compose runtime, so it is a plain string
+         resource rather than a motoHubText() call). -->
+    <string name="handlebar_hid_capture_description">Lets MOTO-HUB read D-pad presses from a Bluetooth HID handlebar remote while HID mode is selected in Handlebar buttons settings.</string>
 </resources>

--- a/translations/strings-it-IT.xml
+++ b/translations/strings-it-IT.xml
@@ -698,4 +698,7 @@
     <string name="legacy_several_manufacturers_ship_the_same_dashboard_so_49305d38">Diversi produttori usano lo stesso software del cruscotto con il proprio marchio, quindi può benissimo essere la tua moto. Continua solo se hai inquadrato il cruscotto della tua moto.</string>
     <!-- Source: feature/pairing/UnverifiedQrDialog.kt -->
     <string name="legacy_use_these_details_52f852ac">Usa questi dati</string>
+
+    <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
+    <string name="handlebar_hid_capture_description">Consente a MOTO-HUB di leggere le pressioni del D-pad da un telecomando manubrio Bluetooth HID quando la modalità HID è selezionata nelle impostazioni dei pulsanti manubrio.</string>
 </resources>

--- a/translations/strings-ko-KR.xml
+++ b/translations/strings-ko-KR.xml
@@ -1269,4 +1269,7 @@
     <string name="legacy_several_manufacturers_ship_the_same_dashboard_so_49305d38">여러 제조사가 같은 계기판 소프트웨어를 자사 브랜드로 사용하므로 본인의 오토바이일 수 있습니다. 본인 계기판에서 스캔한 경우에만 계속하세요.</string>
     <!-- Source: feature/pairing/UnverifiedQrDialog.kt -->
     <string name="legacy_use_these_details_52f852ac">이 정보 사용</string>
+
+    <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
+    <string name="handlebar_hid_capture_description">핸들바 버튼 설정에서 HID 모드가 선택된 경우, MOTO-HUB가 블루투스 HID 핸들바 리모컨의 D패드 입력을 읽을 수 있도록 합니다.</string>
 </resources>

--- a/translations/strings-pt-PT.xml
+++ b/translations/strings-pt-PT.xml
@@ -1280,4 +1280,7 @@
     <string name="legacy_several_manufacturers_ship_the_same_dashboard_so_49305d38">Vários fabricantes usam o mesmo software de painel com a sua própria marca, por isso pode muito bem ser a sua mota. Continue apenas se leu o código no painel da sua mota.</string>
     <!-- Source: feature/pairing/UnverifiedQrDialog.kt -->
     <string name="legacy_use_these_details_52f852ac">Usar estes dados</string>
+
+    <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
+    <string name="handlebar_hid_capture_description">Permite que a MOTO-HUB leia as pressões do D-pad de um comando Bluetooth HID do guiador quando o modo HID está selecionado nas definições de botões do guiador.</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds a full **HID input path** for handlebar buttons alongside the existing AVRCP one — a Bluetooth remote that pairs as a plain HID keyboard (instead of sending AVRCP media-button commands) was previously invisible to MOTO-HUB no matter how it was wired. The new path reuses the *same* gesture/calibration/mapping pipeline rather than duplicating it, so calibration, hold/double-tap timing, and the mapping screen behave identically regardless of transport.

Alongside that, this PR fixes several session/UX bugs found while building and field-testing HID mode end-to-end against a real Bluetooth remote and a Pixel 8 — most are not HID-specific and improve the AVRCP path too.

Everything below was verified on-device via live `adb logcat` capture at each step, not assumption — several of the fixes (VolumeProvider routing loss, reclaim not restoring volume ownership, the Assistant/mic freeze) were only found by catching the failure live in logcat mid-test.

## Handlebar HID mode

- **`HandlebarInputMode`** (AVRCP / HID), persisted per motorcycle like the rest of `HandlebarControlStore`. Settings → Handlebar buttons shows the protocol picker above "Buttons control Android Auto".
- **`HandlebarHidCaptureService`**: an `AccessibilityService` with `FLAG_REQUEST_FILTER_KEY_EVENTS`. HID key events are ordinary input, delivered to whichever window has focus (normally Android Auto's own surface) — `MediaButtonBridge`'s `MediaSession` callback never sees them at all. Entirely inert unless HID mode is selected **and** the rider has granted the service in system Accessibility settings; every event is otherwise returned unconsumed so it reaches whatever app would normally get it.
- **`MediaButtonBridge.onHidKeyEvent()`**: volume/select/track-shaped HID keycodes route through the *same* `onKeyDown`/`onKeyUp`/`detectDoubleTap` machinery AVRCP uses — a HID remote's "up" button **is** `HandlebarGesture.VOLUME_UP`, same calibration, same mapping screen, same hold/double-tap behavior, regardless of transport. Literal D-pad arrow keycodes (a remote wired as a literal 4-way pad) get a fixed, non-teachable arrow mapping instead — there's nothing to learn when the remote already reports which direction was pressed. Unrecognized keycodes are logged with their exact code so a mismatch can be diagnosed from the in-app diagnostic log, no adb needed.

### Bugs fixed in the HID path

- `canReceiveHandlebarKeys()` gated capture on `BLUETOOTH_CONNECT`, which HID mode never needs (the Accessibility Service sees plain input events — no Bluetooth API call involved). This silently blocked capture on a phone that had never granted that permission, even though HID presses were already reaching the Accessibility Service and being dropped downstream. Bypassed for HID mode.
- `installRemoteVolume()`'s `VolumeProvider` was skipped in HID mode on the assumption it wasn't needed. Turns out it's the mechanism that wins hardware volume-key routing away from Android Auto's own app, which otherwise claims it first — confirmed via `MediaSessionService.dispatchVolumeKeyEvent` logs routing straight to `com.google.android.projection.gearhead`. Re-enabled for both modes; its callback now dispatches a HID volume press as the handlebar gesture (`onHidVolumeKey`) instead of "the phone's own volume key".
- After a full `AUDIOFOCUS_LOSS` (observed alongside an Android Auto in-call service binder hiccup, and again after invoking the Assistant), `reclaimCapture()` restored media-button focus but never re-attached the `VolumeProvider` — hardware volume keys stayed mapped to the real system volume for 15+ seconds after "handlebar reclaimed" had already logged. `installRemoteVolume()` is now re-asserted as part of reclaim.
- Invoking the Assistant without `RECORD_AUDIO` granted left Android Auto waiting on a microphone stream that never arrived, freezing handlebar input entirely until a touch on the AA surface reset it — see the phone-only permission-chain fix below.

## Calibration wizard hardening

- The teach wizard used to record *whatever* gesture arrived next for the current step with no check that it actually matched — a single tap during a "double" or "hold" step silently overwrote that binding with the plain press. It now compares the incoming gesture's shape against the step's PRESS-sibling and only accepts a match, showing an on-screen hint ("press twice quickly for double" / "press and hold a moment longer") instead of guessing.
- Volume gestures have no hold variant at all (nothing a "held" volume press could mean over either AVRCP's absolute-value stream or a HID discrete key). A hold step for such a button is now announced ("This button has no hold — skipping automatically", red like a mismatch) and skipped immediately instead of waiting forever for a gesture that can never fire.
- Added `HandlebarGesture.doubleSibling()` / `longSibling()` so both checks work without hardcoding every family by name.

## Phone-only Android Auto exposed in Core's own UI

Core already had `PhoneOnlyAndroidAutoBridge` (Android Auto entirely on the phone, no T-Box), but it was reachable only via the IPC intent Advanced sends.

- Added an **"Android Auto — straight to your phone"** entry to the pairing screen's Connect step (mirrors Advanced's own shortcut), wired to the same bridge in-process.
- **Bug:** `PhoneOnlyAndroidAutoBridge` never created a `MediaButtonBridge` at all — handlebar capture (either mode) had nothing to attach to on this path. Now wired identically to `AndroidAutoSessionService`'s real T-Box session (create+start on bridge start, `setCaptureActive`/reassert on first video frame, stop on session end).
- **Bug:** closing the phone-only preview always stopped the whole session, so navigating to Settings mid-test killed it. Closing the preview now only hides it (session keeps running in the background, like a real T-Box session does when switching tabs) unless it was a launch from Advanced; the existing "reopen preview" and Stop actions are now mode-aware.
- **Bug:** the new phone-only button skipped the `POST_NOTIFICATIONS`/`RECORD_AUDIO` permission chain the real T-Box start already goes through — root cause of the Assistant/mic freeze above. `continueAndroidAutoPhoneOnlyStart()` now mirrors `continueAndroidAutoStart()`.
- **`HandlebarTeachPrerequisiteRequest`** + a dialog on "Teach my handlebar": if no session is running, asks whether to connect to a saved motorcycle (with a choice of which, if more than one) or start phone-only — published as a request since the mapping screen has no session-state or permission-launcher access of its own. Starting from this dialog keeps the phone-only preview closed and opens the teach wizard automatically once the session reaches `Streaming`, no second tap needed.
- `BluetoothStatusCard`'s "no audio device connected" message was accurate for AVRCP (A2DP/HEADSET profile query) but actively wrong for HID — a HID remote never shows up in that list even when working correctly. Now shows Bluetooth on/permitted status instead when HID mode is selected.

## Testing

Field-verified end to end against a real Bluetooth HID handlebar remote on a Pixel 8:

- Mode toggle (AVRCP ↔ HID) and Accessibility Service capture
- Calibration, including the shape-mismatch rejection and the volume-hold auto-skip
- Volume/track/select mapping through to live Android Auto rotary/D-pad/select/back/home input
- Phone-only start from both the Home screen button and the teach prerequisite dialog
- Focus-loss/reclaim and Assistant-freeze recovery paths, caught live via `adb logcat`

`./gradlew testDebugUnitTest lintRelease assembleRelease` all green; release APK built with `-PincludeAndroidAutoIdentity=true`, signed, and installed/tested on-device throughout.

