### PR TITLE
Remove stray unresolved merge marker left in translation catalogues

### DIFF
--- a/translations/strings-en-US.xml
+++ b/translations/strings-en-US.xml
@@ -1533,7 +1533,6 @@
     <!-- Source: feature/trips/TripLibraryUi.kt -->
     <string name="legacy_enhanced_9c6c8376">ENHANCED</string>
     <string name="legacy_gps_only_e6f03982">GPS ONLY</string>
-=======
     <!-- Source: feature/controls/HandlebarHidCaptureService.kt (system Accessibility settings
          description; rendered outside the app's own Compose runtime, so it is a plain string
          resource rather than a motoHubText() call). -->

--- a/translations/strings-it-IT.xml
+++ b/translations/strings-it-IT.xml
@@ -957,7 +957,6 @@
     <!-- Source: feature/trips/TripLibraryUi.kt -->
     <string name="legacy_enhanced_9c6c8376">COMPLETO</string>
     <string name="legacy_gps_only_e6f03982">SOLO GPS</string>
-=======
     <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
     <string name="handlebar_hid_capture_description">Consente a MOTO-HUB di leggere le pressioni del D-pad da un telecomando manubrio Bluetooth HID quando la modalità HID è selezionata nelle impostazioni dei pulsanti manubrio.</string>
 

--- a/translations/strings-ko-KR.xml
+++ b/translations/strings-ko-KR.xml
@@ -1528,7 +1528,6 @@
     <!-- Source: feature/trips/TripLibraryUi.kt -->
     <string name="legacy_enhanced_9c6c8376">전체 기록</string>
     <string name="legacy_gps_only_e6f03982">GPS만</string>
-=======
     <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
     <string name="handlebar_hid_capture_description">핸들바 버튼 설정에서 HID 모드가 선택된 경우, MOTO-HUB가 블루투스 HID 핸들바 리모컨의 D패드 입력을 읽을 수 있도록 합니다.</string>
 

--- a/translations/strings-pt-PT.xml
+++ b/translations/strings-pt-PT.xml
@@ -957,7 +957,6 @@
     <!-- Source: feature/trips/TripLibraryUi.kt -->
     <string name="legacy_enhanced_9c6c8376">COMPLETO</string>
     <string name="legacy_gps_only_e6f03982">SÓ GPS</string>
-=======
     <!-- Source: feature/controls/HandlebarHidCaptureService.kt -->
     <string name="handlebar_hid_capture_description">Permite que a MOTO-HUB leia as pressões do D-pad de um comando Bluetooth HID do guiador quando o modo HID está selecionado nas definições de botões do guiador.</string>
 


### PR DESCRIPTION
A literal `=======` line survived a merge/rebase and got committed into all four `strings-*.xml` files (`strings-en-US.xml`, `strings-it-IT.xml`, `strings-ko-KR.xml`, `strings-pt-PT.xml`), sitting as bare text between two `<string>` elements inside `<resources>`.

Found while merging `main` into a fork: harmless to a lenient XML parser (it's stray character data outside any tag, not malformed markup), but obviously an accidental leftover from resolving a conflict, not intentional content. This PR just removes the four stray lines — no other changes.